### PR TITLE
Implement buffer flow control

### DIFF
--- a/sim_core/event.py
+++ b/sim_core/event.py
@@ -13,4 +13,4 @@ class Event:
 
     def handle(self):
         if self.dst is not None:
-            self.dst.handle_event(self)
+            self.dst._process_event(self)

--- a/sim_core/mesh.py
+++ b/sim_core/mesh.py
@@ -1,11 +1,11 @@
 from .router import Router
 
-def create_mesh(engine, x_size, y_size, mesh_info):
+def create_mesh(engine, x_size, y_size, mesh_info, buffer_capacity=4):
     mesh = {}
     for x in range(x_size):
         for y in range(y_size):
             name = f"Router_{x}_{y}"
-            router = Router(engine, name, x, y, mesh_info)
+            router = Router(engine, name, x, y, mesh_info, buffer_capacity=buffer_capacity)
             mesh[(x, y)] = router
             engine.register_module(router)
     for x in range(x_size):

--- a/sim_core/module.py
+++ b/sim_core/module.py
@@ -2,23 +2,55 @@ from .event import Event
 
 
 class HardwareModule:
-    def __init__(self, engine, name, mesh_info):
+    def __init__(self, engine, name, mesh_info, buffer_capacity=4):
         self.engine = engine
         self.name = name
         self.mesh_info = mesh_info
-    
+        self.buffer_capacity = buffer_capacity
+        self.buffer_occupancy = 0
+
+    # Credit based buffer bookkeeping
+    def _reserve_slot(self):
+        if self.buffer_occupancy >= self.buffer_capacity:
+            return False
+        self.buffer_occupancy += 1
+        return True
+
+    def _release_slot(self):
+        if self.buffer_occupancy > 0:
+            self.buffer_occupancy -= 1
+
+    def can_accept_event(self):
+        return self.buffer_occupancy < self.buffer_capacity
+
+    def _process_event(self, event):
+        try:
+            self.handle_event(event)
+        finally:
+            self._release_slot()
+
     def handle_event(self, event):
-        pass
+        if event.event_type == "RETRY_SEND":
+            retry_evt = event.payload["event"]
+            self.send_event(retry_evt)
 
     def send_event(self, event):
-        self.engine.push_event(event)
+        if not event.dst._reserve_slot():
+            # Destination buffer full; stall and retry next cycle
+            if hasattr(self, "set_stall"):
+                self.set_stall(1)
+            retry = Event(src=self, dst=self, cycle=self.engine.current_cycle + 1,
+                           event_type="RETRY_SEND", payload={"event": event})
+            self.engine.push_event(retry)
+        else:
+            self.engine.push_event(event)
 
 
 class PipelineModule(HardwareModule):
     """Base class for modules with simple pipelined execution."""
 
-    def __init__(self, engine, name, mesh_info, num_stages):
-        super().__init__(engine, name, mesh_info)
+    def __init__(self, engine, name, mesh_info, num_stages, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
         self.num_stages = num_stages
         self.stage_funcs = [lambda m, d: (d, i + 1, False)
                            for i in range(num_stages)]

--- a/sim_core/router.py
+++ b/sim_core/router.py
@@ -2,8 +2,8 @@ from .module import HardwareModule
 from .event import Event
 
 class Router(HardwareModule):
-    def __init__(self, engine, name, mesh_x, mesh_y, mesh_info, bitwidth=256, pipeline_delay=4):
-        super().__init__(engine, name, mesh_info)
+    def __init__(self, engine, name, mesh_x, mesh_y, mesh_info, bitwidth=256, pipeline_delay=4, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
         self.x = mesh_x
         self.y = mesh_y
         self.bitwidth = bitwidth
@@ -15,13 +15,26 @@ class Router(HardwareModule):
         self.neighbors = neighbor_dict
 
     def handle_event(self, event):
+        if event.event_type == "RETRY_SEND":
+            super().handle_event(event)
+            return
+
         dst_coords = event.payload.get("dst_coords", None)
         if dst_coords is None:
             raise ValueError(f"[{self.name}] 이벤트 payload에 dst_coords가 없습니다.")
         if (self.x, self.y) == dst_coords:
             if self.attached_module is None:
                 raise RuntimeError(f"[{self.name}] attached_module이 없습니다!")
-            self.attached_module.handle_event(event)
+            new_event = Event(
+                src=self,
+                dst=self.attached_module,
+                cycle=self.engine.current_cycle + 1,
+                data_size=event.data_size,
+                identifier=event.identifier,
+                event_type=event.event_type,
+                payload=event.payload,
+            )
+            self.send_event(new_event)
             return
         next_dir = None
         dx, dy = dst_coords[0] - self.x, dst_coords[1] - self.y

--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -2,8 +2,8 @@ from sim_core.module import HardwareModule
 from sim_core.event import Event
 
 class ControlProcessor(HardwareModule):
-    def __init__(self, engine, name, mesh_info, pes, dram):
-        super().__init__(engine, name, mesh_info)
+    def __init__(self, engine, name, mesh_info, pes, dram, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
         self.pes = pes
         self.dram = dram
         self.active_gemms = {}
@@ -98,7 +98,7 @@ class ControlProcessor(HardwareModule):
                 self.active_gemms.pop(event.identifier, None)
 
         else:
-            print(f"[CP] 알 수 없는 이벤트: {event.event_type}")
+            super().handle_event(event)
 
     def get_my_router(self):
         coords = self.mesh_info["cp_coords"][self.name]

--- a/sim_hw/dram.py
+++ b/sim_hw/dram.py
@@ -2,8 +2,8 @@ from sim_core.module import HardwareModule
 from sim_core.event import Event
 
 class DRAM(HardwareModule):
-    def __init__(self, engine, name, mesh_info):
-        super().__init__(engine, name, mesh_info)
+    def __init__(self, engine, name, mesh_info, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
 
     def handle_event(self, event):
         if event.event_type == "DMA_WRITE":
@@ -35,7 +35,7 @@ class DRAM(HardwareModule):
             )
             self.send_event(reply_event)
         else:
-            print(f"[{self.name}] 알 수 없는 이벤트: {event.event_type}")
+            super().handle_event(event)
 
     def get_my_router(self):
         coords = self.mesh_info["dram_coords"][self.name]

--- a/sim_hw/pe.py
+++ b/sim_hw/pe.py
@@ -3,8 +3,8 @@ from sim_core.event import Event
 import random
 
 class PE(PipelineModule):
-    def __init__(self, engine, name, mesh_info, mac_units=32, mac_width=32, pipeline_stages=5):
-        super().__init__(engine, name, mesh_info, pipeline_stages)
+    def __init__(self, engine, name, mesh_info, mac_units=32, mac_width=32, pipeline_stages=5, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, pipeline_stages, buffer_capacity)
         self.mac_units = mac_units
         self.mac_width = mac_width
         self.expected_dma_reads = {}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,6 @@
 import unittest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from sim_core.engine import SimulatorEngine
 from sim_core.mesh import create_mesh
 from sim_core.event import Event
@@ -16,17 +18,17 @@ class PipelineSimTest(unittest.TestCase):
             "cp_coords": {},
             "dram_coords": {},
         }
-        mesh = create_mesh(engine, 3, 1, mesh_info)
+        mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
         mesh_info["router_map"] = mesh
-        pe = PE(engine, "PE_0", mesh_info)
+        pe = PE(engine, "PE_0", mesh_info, buffer_capacity=1)
         mesh_info["pe_coords"]["PE_0"] = (0,0)
         mesh[(0,0)].attached_module = pe
         engine.register_module(pe)
-        dram = DRAM(engine, "DRAM", mesh_info)
+        dram = DRAM(engine, "DRAM", mesh_info, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
         mesh[(1,0)].attached_module = dram
         engine.register_module(dram)
-        cp = ControlProcessor(engine, "CP", mesh_info, [pe], dram)
+        cp = ControlProcessor(engine, "CP", mesh_info, [pe], dram, buffer_capacity=1)
         mesh_info["cp_coords"]["CP"] = (2,0)
         mesh[(2,0)].attached_module = cp
         engine.register_module(cp)


### PR DESCRIPTION
## Summary
- add credit-based buffering to `HardwareModule`
- propagate buffer capacity through routers and hardware blocks
- retry sends when destination buffers are full
- adjust unit test to exercise stalling behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b78a0a7f083308e2f5d0d4b3c5e54