### PR TITLE
Add pipeline event timeline logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The simulator is composed of a few key building blocks:
   * Coordinates GEMM operations by sending commands to PEs and waits for completion messages.
 * **DRAM** (`sim_hw/dram.py`)
   * Handles DMA read/write events emitted by PEs and NPUs.
+* **Event Logger** (`sim_core/logger.py`)
+  * Records which event types each module handles every cycle and can plot a
+    timeline showing pipeline activity across modules.
 
 ## Package Layout
 
@@ -34,7 +37,7 @@ The simulator is composed of a few key building blocks:
    ```bash
    python main.py
    ```
-   The script builds a simple mesh, registers hardware modules and executes a fake decoder block. During the forward pass the hooks inject GEMM events which the simulator processes.
+   The script builds a simple mesh, registers hardware modules and executes a fake decoder block. During the forward pass the hooks inject GEMM events which the simulator processes. After completion a `timeline.png` file is generated visualizing which module processed which events each cycle.
 
 ## Testing
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from sim_core.engine import SimulatorEngine
 from sim_core.mesh import create_mesh
+from sim_core.logger import EventLogger
 from sim_hw.cp import ControlProcessor
 from sim_hw.pe import PE
 from sim_hw.dram import DRAM
@@ -9,6 +10,8 @@ import torch
 
 def main():
     engine = SimulatorEngine()
+    logger = EventLogger()
+    engine.set_logger(logger)
     x_size, y_size = 3, 2
 
     mesh_info = {
@@ -59,6 +62,7 @@ def main():
     print("===== PyTorch Llama3 Decoder Forward (w/ 하드웨어 시뮬레이터) =====")
     y = block(x)
     engine.run_until_idle()
+    logger.plot('timeline.png')
 
 if __name__ == "__main__":
     main()

--- a/sim_core/engine.py
+++ b/sim_core/engine.py
@@ -5,9 +5,14 @@ class SimulatorEngine:
         self.current_cycle = 0
         self.event_queue = []
         self.modules = {}
+        self.logger = None
     
     def register_module(self, module):
         self.modules[module.name] = module
+
+    def set_logger(self, logger):
+        """Attach an EventLogger instance."""
+        self.logger = logger
 
     def push_event(self, event):
         heapq.heappush(self.event_queue, event)

--- a/sim_core/logger.py
+++ b/sim_core/logger.py
@@ -1,0 +1,53 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from collections import defaultdict
+
+class EventLogger:
+    """Collects handled events for plotting."""
+    def __init__(self):
+        self.entries = []  # list of (cycle, module, stage, event_type)
+
+    def log_event(self, cycle, module, stage, event_type):
+        self.entries.append({
+            'cycle': cycle,
+            'module': module,
+            'stage': stage,
+            'event_type': event_type,
+        })
+
+    def get_entries(self):
+        return list(self.entries)
+
+    def plot(self, path='timeline.png'):
+        if not self.entries:
+            print('No events to plot')
+            return
+        modules = sorted({e['module'] for e in self.entries})
+        # determine stage count per module
+        stage_counts = {m: max((e['stage'] for e in self.entries if e['module']==m), default=0) + 1
+                        for m in modules}
+        offsets = {}
+        y_labels = []
+        y_positions = []
+        offset = 0
+        for m in modules:
+            offsets[m] = offset
+            for s in range(stage_counts[m]):
+                y_labels.append(f"{m}[{s}]")
+                y_positions.append(offset + s)
+            offset += stage_counts[m] + 1  # gap between modules
+        cmap = plt.get_cmap('tab10')
+        fig, ax = plt.subplots(figsize=(10, max(3, len(y_positions)*0.4)))
+        for idx, m in enumerate(modules):
+            color = cmap(idx % 10)
+            xs = [e['cycle'] for e in self.entries if e['module']==m]
+            ys = [offsets[m]+e['stage'] for e in self.entries if e['module']==m]
+            ax.scatter(xs, ys, label=m, color=color, s=10)
+        ax.set_xlabel('Cycle')
+        ax.set_yticks(y_positions)
+        ax.set_yticklabels(y_labels)
+        ax.legend(bbox_to_anchor=(1.04,1), loc='upper left')
+        fig.tight_layout()
+        fig.savefig(path)
+        plt.close(fig)

--- a/sim_core/module.py
+++ b/sim_core/module.py
@@ -25,6 +25,9 @@ class HardwareModule:
 
     def _process_event(self, event):
         try:
+            if self.engine.logger:
+                stage = event.payload.get('stage_idx', 0) if isinstance(event.payload, dict) else 0
+                self.engine.logger.log_event(self.engine.current_cycle, self.name, stage, event.event_type)
             self.handle_event(event)
         finally:
             self._release_slot()


### PR DESCRIPTION
## Summary
- add `EventLogger` for capturing events and plotting per-cycle timeline
- log events in `HardwareModule` and integrate logger with `SimulatorEngine`
- expose logging in `main.py` and document in README

## Testing
- `python -m unittest discover tests`
- `python main.py` *(fails: manual run aborted due to long execution)*

------
https://chatgpt.com/codex/tasks/task_e_6853c735056483309cb1b752e208d5ce