### PR TITLE
Add DRAM pipeline and support task cycles

### DIFF
--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -107,6 +107,7 @@ class ControlProcessor(HardwareModule):
                 "task_cycles": event.payload["task_cycles"],
                 "in_size": event.payload["in_size"],
                 "out_size": event.payload["out_size"],
+                "dram_cycles": event.payload.get("dram_cycles", 5),
             }
             self.active_npu_tasks[event.identifier] = state
             for npu in self.npus:
@@ -123,6 +124,7 @@ class ControlProcessor(HardwareModule):
                         "cp_name": self.name,
                         "dram_name": self.dram.name,
                         "npu_name": npu.name,
+                        "task_cycles": state["dram_cycles"],
                     },
                 )
                 self.send_event(dma_evt)
@@ -171,6 +173,7 @@ class ControlProcessor(HardwareModule):
                             "cp_name": self.name,
                             "dram_name": self.dram.name,
                             "npu_name": npu.name,
+                            "task_cycles": state["dram_cycles"],
                         },
                     )
                     self.send_event(dma_evt)

--- a/sim_hw/npu.py
+++ b/sim_hw/npu.py
@@ -64,6 +64,7 @@ class NPU(PipelineModule):
                         "dst_coords": dram_coords,
                         "pe_name": self.name,
                         "cp_name": event.payload["cp_name"],
+                        "task_cycles": event.payload.get("task_cycles", 5),
                     },
                 )
                 self.send_event(read_evt)
@@ -109,6 +110,7 @@ class NPU(PipelineModule):
                         "dst_coords": dram_coords,
                         "pe_name": self.name,
                         "cp_name": event.payload["cp_name"],
+                        "task_cycles": event.payload.get("task_cycles", 5),
                     },
                 )
                 self.send_event(wr_evt)

--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -26,7 +26,7 @@ class NPUTest(unittest.TestCase):
         mesh_info["pe_coords"]["NPU_0"] = (0,0)
         mesh[(0,0)].attached_module = npu
         engine.register_module(npu)
-        dram = DRAM(engine, "DRAM", mesh_info, buffer_capacity=1)
+        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
         mesh[(1,0)].attached_module = dram
         engine.register_module(dram)
@@ -45,6 +45,7 @@ class NPUTest(unittest.TestCase):
                 "task_cycles": 3,
                 "in_size": 16,
                 "out_size": 16,
+                "dram_cycles": 2,
             },
         )
         cp.send_event(event)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,7 +24,7 @@ class PipelineSimTest(unittest.TestCase):
         mesh_info["pe_coords"]["PE_0"] = (0,0)
         mesh[(0,0)].attached_module = pe
         engine.register_module(pe)
-        dram = DRAM(engine, "DRAM", mesh_info, buffer_capacity=1)
+        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
         mesh[(1,0)].attached_module = dram
         engine.register_module(dram)


### PR DESCRIPTION
## Summary
- refactor `DRAM` into a `PipelineModule` so read/write replies occur only after pipeline completion
- propagate configurable pipeline latency through CP and NPU
- update tests to use new DRAM pipeline behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592db630f883309e87f32e3159225d