### PR TITLE
Refactor event reply handling

### DIFF
--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -33,9 +33,10 @@ class ControlProcessor(HardwareModule):
                     payload={
                         "dst_coords": self.mesh_info["pe_coords"][pe.name],
                         "data_size": state["weights_size"] + state["act_size"],
-                        "cp_name": self.name,
                         "dram_name": self.dram.name,
                         "pe_name": pe.name,
+                        "need_reply": True,
+                        "reply_coords": self.mesh_info["cp_coords"][self.name],
                     },
                 )
                 self.send_event(dma_evt)
@@ -58,7 +59,8 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["pe_coords"][pe.name],
                             "gemm_shape": state["gemm_shape"],
-                            "cp_name": self.name,
+                            "need_reply": True,
+                            "reply_coords": self.mesh_info["cp_coords"][self.name],
                         },
                     )
                     self.send_event(gemm_evt)
@@ -82,9 +84,10 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["pe_coords"][pe.name],
                             "data_size": out_size,
-                            "cp_name": self.name,
                             "pe_name": pe.name,
                             "dram_name": self.dram.name,
+                            "need_reply": True,
+                            "reply_coords": self.mesh_info["cp_coords"][self.name],
                         },
                     )
                     self.send_event(dma_evt)
@@ -121,10 +124,11 @@ class ControlProcessor(HardwareModule):
                     payload={
                         "dst_coords": self.mesh_info["npu_coords"][npu.name],
                         "data_size": state["in_size"],
-                        "cp_name": self.name,
                         "dram_name": self.dram.name,
                         "npu_name": npu.name,
                         "task_cycles": state["dram_cycles"],
+                        "need_reply": True,
+                        "reply_coords": self.mesh_info["cp_coords"][self.name],
                     },
                 )
                 self.send_event(dma_evt)
@@ -147,7 +151,8 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["npu_coords"][npu.name],
                             "task_cycles": state["task_cycles"],
-                            "cp_name": self.name,
+                            "need_reply": True,
+                            "reply_coords": self.mesh_info["cp_coords"][self.name],
                         },
                     )
                     self.send_event(cmd_evt)
@@ -170,10 +175,11 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["npu_coords"][npu.name],
                             "data_size": state["out_size"],
-                            "cp_name": self.name,
                             "dram_name": self.dram.name,
                             "npu_name": npu.name,
                             "task_cycles": state["dram_cycles"],
+                            "need_reply": True,
+                            "reply_coords": self.mesh_info["cp_coords"][self.name],
                         },
                     )
                     self.send_event(dma_evt)

--- a/sim_hw/dram.py
+++ b/sim_hw/dram.py
@@ -21,8 +21,9 @@ class DRAM(PipelineModule):
                 "type": event.event_type,
                 "identifier": event.identifier,
                 "pe_name": event.payload["pe_name"],
-                "cp_name": event.payload["cp_name"],
                 "remaining": event.payload.get("task_cycles", self.pipeline_latency),
+                "need_reply": event.payload.get("need_reply", False),
+                "reply_coords": event.payload.get("reply_coords"),
             }
             self.add_data(task)
         else:
@@ -42,7 +43,8 @@ class DRAM(PipelineModule):
             event_type=evt_type,
             payload={
                 "dst_coords": self.mesh_info["pe_coords"][task["pe_name"]],
-                "cp_name": task["cp_name"],
+                "need_reply": task.get("need_reply", False),
+                "reply_coords": task.get("reply_coords"),
             },
         )
         self.send_event(reply_event)


### PR DESCRIPTION
## Summary
- simplify reply path by using `reply_coords` and `need_reply`
- propagate these fields through PE, NPU, DRAM and CP
- update pipeline modules to return events to the new coordinates

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_685a02749fa08330ac40e94e765f3fc5