### PR TITLE
Refactor payloads for pipeline modules

### DIFF
--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -33,9 +33,8 @@ class ControlProcessor(HardwareModule):
                     payload={
                         "dst_coords": self.mesh_info["pe_coords"][pe.name],
                         "data_size": state["weights_size"] + state["act_size"],
-                        "cp_name": self.name,
-                        "dram_name": self.dram.name,
-                        "pe_name": pe.name,
+                        "src_name": self.name,
+                        "need_reply": True,
                     },
                 )
                 self.send_event(dma_evt)
@@ -58,7 +57,8 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["pe_coords"][pe.name],
                             "gemm_shape": state["gemm_shape"],
-                            "cp_name": self.name,
+                            "src_name": self.name,
+                            "need_reply": True,
                         },
                     )
                     self.send_event(gemm_evt)
@@ -82,9 +82,9 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["pe_coords"][pe.name],
                             "data_size": out_size,
-                            "cp_name": self.name,
+                            "src_name": self.name,
+                            "need_reply": True,
                             "pe_name": pe.name,
-                            "dram_name": self.dram.name,
                         },
                     )
                     self.send_event(dma_evt)
@@ -121,9 +121,8 @@ class ControlProcessor(HardwareModule):
                     payload={
                         "dst_coords": self.mesh_info["npu_coords"][npu.name],
                         "data_size": state["in_size"],
-                        "cp_name": self.name,
-                        "dram_name": self.dram.name,
-                        "npu_name": npu.name,
+                        "src_name": self.name,
+                        "need_reply": True,
                         "task_cycles": state["dram_cycles"],
                     },
                 )
@@ -147,7 +146,8 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["npu_coords"][npu.name],
                             "task_cycles": state["task_cycles"],
-                            "cp_name": self.name,
+                            "src_name": self.name,
+                            "need_reply": True,
                         },
                     )
                     self.send_event(cmd_evt)
@@ -170,9 +170,8 @@ class ControlProcessor(HardwareModule):
                         payload={
                             "dst_coords": self.mesh_info["npu_coords"][npu.name],
                             "data_size": state["out_size"],
-                            "cp_name": self.name,
-                            "dram_name": self.dram.name,
-                            "npu_name": npu.name,
+                            "src_name": self.name,
+                            "need_reply": True,
                             "task_cycles": state["dram_cycles"],
                         },
                     )

--- a/sim_hw/dram.py
+++ b/sim_hw/dram.py
@@ -20,10 +20,11 @@ class DRAM(PipelineModule):
             task = {
                 "type": event.event_type,
                 "identifier": event.identifier,
-                "pe_name": event.payload["pe_name"],
-                "cp_name": event.payload["cp_name"],
+                "src_name": event.payload["src_name"],
                 "remaining": event.payload.get("task_cycles", self.pipeline_latency),
             }
+            if event.payload.get("need_reply"):
+                task["dst_name"] = event.payload["src_name"]
             self.add_data(task)
         else:
             super().handle_event(event)
@@ -33,19 +34,23 @@ class DRAM(PipelineModule):
             evt_type = "WRITE_REPLY"
         else:
             evt_type = "DMA_READ_REPLY"
-        reply_event = Event(
-            src=self,
-            dst=self.get_my_router(),
-            cycle=self.engine.current_cycle,
-            data_size=4,
-            identifier=task["identifier"],
-            event_type=evt_type,
-            payload={
-                "dst_coords": self.mesh_info["pe_coords"][task["pe_name"]],
-                "cp_name": task["cp_name"],
-            },
-        )
-        self.send_event(reply_event)
+        if "dst_name" in task:
+            dst_name = task["dst_name"]
+            coords = (self.mesh_info.get("pe_coords", {}).get(dst_name)
+                      or self.mesh_info.get("npu_coords", {}).get(dst_name)
+                      or self.mesh_info.get("cp_coords", {}).get(dst_name))
+            reply_event = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=4,
+                identifier=task["identifier"],
+                event_type=evt_type,
+                payload={
+                    "dst_coords": coords,
+                },
+            )
+            self.send_event(reply_event)
 
     def get_my_router(self):
         coords = self.mesh_info["dram_coords"][self.name]


### PR DESCRIPTION
## Summary
- remove explicit cp/dram names from command payloads
- pipe modules now track source via `src_name` and `need_reply`
- update DRAM to handle generic tasks and send replies back using stored dst name
- adjust PE and NPU logic for new payload fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a095161b08330a799db007ba83f6a