### PR TITLE
Enhance router with VC pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The simulator is composed of a few key building blocks:
 * **Engine** (`sim_core/engine.py`)
   * Maintains the global cycle counter and delivers queued `Event` objects in timestamp order.
 * **Routers** (`sim_core/router.py`)
-  * Form a 2‑D mesh created via `sim_core/mesh.py`.
-  * Forward events toward destination coordinates and can host a hardware module.
+  * Form a 2-D mesh created via `sim_core/mesh.py`.
+  * Forward events through a 4-stage pipeline using virtual channels.
 * **Processing Elements (PEs)** (`sim_hw/pe.py`)
   * Simulate matrix-multiplication units that communicate with DRAM.
 * **Control Processor (CP)** (`sim_hw/cp.py`)
@@ -49,4 +49,10 @@ Two scenarios are covered:
 
 * **GEMM pipeline** (`tests/test_pipeline.py`) – Validates that a CP can orchestrate GEMM operations across a PE and DRAM, ensuring all DMA and computation events complete.
 * **NPU task flow** (`tests/test_npu.py`) – Exercises an NPU performing a simple task requiring DMA transfers in/out of DRAM. The test confirms the CP tracks completion of the task.
+
+
+## Uniform Traffic Example
+
+Run `examples/uniform_traffic.py` to simulate uniform random traffic on a 16x16 mesh.
+The script reports the average waiting time of delivered packets.
 

--- a/examples/uniform_traffic.py
+++ b/examples/uniform_traffic.py
@@ -1,0 +1,36 @@
+from sim_core.engine import SimulatorEngine
+from sim_core.mesh import create_mesh
+from sim_hw.traffic_gen import TrafficGenerator
+
+
+def run_uniform_traffic(x=16, y=16, packets_per_node=20, max_tick=10000):
+    engine = SimulatorEngine()
+    mesh_info = {
+        "mesh_size": (x, y),
+        "router_map": None,
+    }
+    mesh = create_mesh(engine, x, y, mesh_info)
+    mesh_info["router_map"] = mesh
+
+    gens = []
+    for cx in range(x):
+        for cy in range(y):
+            name = f"TG_{cx}_{cy}"
+            tg = TrafficGenerator(engine, name, mesh_info, (cx, cy), packets_per_node)
+            mesh[(cx, cy)].attach_module(tg)
+            engine.register_module(tg)
+            tg.start()
+            gens.append(tg)
+
+    engine.run_until_idle(max_tick=max_tick)
+
+    latencies = [lat for g in gens for lat in g.latencies]
+    avg = sum(latencies) / len(latencies) if latencies else 0
+    print(f"Generated packets: {sum(g.sent for g in gens)}")
+    print(f"Received packets: {sum(g.received for g in gens)}")
+    print(f"Average waiting time: {avg:.2f} cycles")
+    return avg
+
+
+if __name__ == "__main__":
+    run_uniform_traffic()

--- a/main.py
+++ b/main.py
@@ -37,16 +37,16 @@ def main():
         pe_name = f"PE_{i}"
         mesh_info["pe_coords"][pe_name] = coords
         pe = PE(engine, pe_name, mesh_info)
-        mesh[coords].attached_module = pe
+        mesh[coords].attach_module(pe)
         engine.register_module(pe)
         pes.append(pe)
 
     dram = DRAM(engine, "DRAM", mesh_info)
-    mesh[dram_coords_dict["DRAM"]].attached_module = dram
+    mesh[dram_coords_dict["DRAM"]].attach_module(dram)
     engine.register_module(dram)
 
     cp = ControlProcessor(engine, "CP", mesh_info, pes, dram)
-    mesh[cp_coords_dict["CP"]].attached_module = cp
+    mesh[cp_coords_dict["CP"]].attach_module(cp)
     engine.register_module(cp)
 
     hidden_size = 32

--- a/sim_core/mesh.py
+++ b/sim_core/mesh.py
@@ -1,11 +1,11 @@
 from .router import Router
 
-def create_mesh(engine, x_size, y_size, mesh_info, buffer_capacity=4):
+def create_mesh(engine, x_size, y_size, mesh_info, buffer_capacity=4, num_vcs=2):
     mesh = {}
     for x in range(x_size):
         for y in range(y_size):
             name = f"Router_{x}_{y}"
-            router = Router(engine, name, x, y, mesh_info, buffer_capacity=buffer_capacity)
+            router = Router(engine, name, x, y, mesh_info, buffer_capacity=buffer_capacity, num_vcs=num_vcs)
             mesh[(x, y)] = router
             engine.register_module(router)
     for x in range(x_size):

--- a/sim_core/module.py
+++ b/sim_core/module.py
@@ -10,17 +10,17 @@ class HardwareModule:
         self.buffer_occupancy = 0
 
     # Credit based buffer bookkeeping
-    def _reserve_slot(self):
+    def _reserve_slot(self, event=None):
         if self.buffer_occupancy >= self.buffer_capacity:
             return False
         self.buffer_occupancy += 1
         return True
 
-    def _release_slot(self):
+    def _release_slot(self, event=None):
         if self.buffer_occupancy > 0:
             self.buffer_occupancy -= 1
 
-    def can_accept_event(self):
+    def can_accept_event(self, event=None):
         return self.buffer_occupancy < self.buffer_capacity
 
     def _process_event(self, event):
@@ -30,7 +30,7 @@ class HardwareModule:
                 self.engine.logger.log_event(self.engine.current_cycle, self.name, stage, event.event_type)
             self.handle_event(event)
         finally:
-            self._release_slot()
+            self._release_slot(event)
 
     def handle_event(self, event):
         if event.event_type == "RETRY_SEND":
@@ -38,7 +38,7 @@ class HardwareModule:
             self.send_event(retry_evt)
 
     def send_event(self, event):
-        if not event.dst._reserve_slot():
+        if not event.dst._reserve_slot(event):
             # Destination buffer full; stall and retry next cycle
             if hasattr(self, "set_stall"):
                 self.set_stall(1)

--- a/sim_core/router.py
+++ b/sim_core/router.py
@@ -1,59 +1,228 @@
 from .module import HardwareModule
 from .event import Event
 
+DIRS = ["LOCAL", "E", "W", "N", "S"]
+DIR_INDEX = {d: i for i, d in enumerate(DIRS)}
+OPPOSITE = {"E": "W", "W": "E", "N": "S", "S": "N", "LOCAL": "LOCAL"}
+
 class Router(HardwareModule):
-    def __init__(self, engine, name, mesh_x, mesh_y, mesh_info, bitwidth=256, pipeline_delay=4, buffer_capacity=4):
+    """Simple high-radix router with virtual-channel based 4-stage pipeline."""
+
+    def __init__(self, engine, name, mesh_x, mesh_y, mesh_info,
+                 bitwidth=256, pipeline_delay=4,
+                 num_ports=5, num_vcs=2, buffer_capacity=4):
         super().__init__(engine, name, mesh_info, buffer_capacity)
         self.x = mesh_x
         self.y = mesh_y
         self.bitwidth = bitwidth
         self.pipeline_delay = pipeline_delay
+        self.num_ports = num_ports
+        self.num_vcs = num_vcs
+
+        # input buffers per [port][vc]
+        self.input_buffers = [[[] for _ in range(num_vcs)]
+                              for _ in range(num_ports)]
+        self.buffer_counts = [[0 for _ in range(num_vcs)]
+                              for _ in range(num_ports)]
+
+        # pipeline state per input port
+        self.port_stage = [0 for _ in range(num_ports)]  # 0=RC,1=VA,2=SA,3=ST
+        self.port_current_event = [None for _ in range(num_ports)]
+        self.port_current_vc = [None for _ in range(num_ports)]
+        self.port_scheduled = [False for _ in range(num_ports)]
+        self.input_rr = [0 for _ in range(num_ports)]
+
+        # output side resources
+        self.output_links = [None for _ in range(num_ports)]  # (dst, dst_port)
+        self.output_vc_allocation = [[None for _ in range(num_vcs)]
+                                     for _ in range(num_ports)]
+        self.vc_rr = [0 for _ in range(num_ports)]
+        self.crossbar_busy = [False for _ in range(num_ports)]
+
         self.neighbors = {}
         self.attached_module = None
 
+    # ------------------------------------------------------------------
+    # basic infrastructure overrides
+    def _process_event(self, event):
+        """Router delays releasing reserved slot until packet leaves."""
+        if self.engine.logger:
+            stage = event.payload.get('stage_idx', 0) if isinstance(event.payload, dict) else 0
+            self.engine.logger.log_event(self.engine.current_cycle, self.name, stage, event.event_type)
+        self.handle_event(event)
+        # no release here; released when packet is forwarded
+
+    def _reserve_slot(self, event=None):
+        port = event.payload.get("input_port", 0) if event else 0
+        vc = event.payload.get("vc", 0) if event else 0
+        if self.buffer_counts[port][vc] >= self.buffer_capacity:
+            return False
+        self.buffer_counts[port][vc] += 1
+        return True
+
+    def _release_slot(self, event):
+        port = event.get("input_port", 0)
+        vc = event.get("vc", 0)
+        if self.buffer_counts[port][vc] > 0:
+            self.buffer_counts[port][vc] -= 1
+
+    def can_accept_event(self, event=None):
+        port = event.payload.get("input_port", 0) if event else 0
+        vc = event.payload.get("vc", 0) if event else 0
+        return self.buffer_counts[port][vc] < self.buffer_capacity
+
+    # ------------------------------------------------------------------
     def set_neighbors(self, neighbor_dict):
         self.neighbors = neighbor_dict
+        for d, n in neighbor_dict.items():
+            out_port = DIR_INDEX[d]
+            in_port = DIR_INDEX[OPPOSITE[d]]
+            self.output_links[out_port] = (n, in_port)
+
+    def attach_module(self, mod):
+        self.attached_module = mod
+        self.output_links[DIR_INDEX["LOCAL"]] = (mod, None)
+
+    # ------------------------------------------------------------------
+    def _schedule_port(self, port):
+        if not self.port_scheduled[port]:
+            evt = Event(src=self, dst=self, cycle=self.engine.current_cycle + 1,
+                        event_type="PORT_STAGE", payload={"port": port})
+            self.engine.push_event(evt)
+            self.port_scheduled[port] = True
 
     def handle_event(self, event):
         if event.event_type == "RETRY_SEND":
             super().handle_event(event)
             return
-
-        dst_coords = event.payload.get("dst_coords", None)
-        if dst_coords is None:
-            raise ValueError(f"[{self.name}] 이벤트 payload에 dst_coords가 없습니다.")
-        if (self.x, self.y) == dst_coords:
-            if self.attached_module is None:
-                raise RuntimeError(f"[{self.name}] attached_module이 없습니다!")
-            new_event = Event(
-                src=self,
-                dst=self.attached_module,
-                cycle=self.engine.current_cycle + 1,
-                data_size=event.data_size,
-                identifier=event.identifier,
-                event_type=event.event_type,
-                payload=event.payload,
-            )
-            self.send_event(new_event)
+        if event.event_type == "PORT_STAGE":
+            port = event.payload["port"]
+            self.port_scheduled[port] = False
+            stage = self.port_stage[port]
+            if stage == 0:
+                self._stage_rc(port)
+            elif stage == 1:
+                self._stage_va(port)
+            elif stage == 2:
+                self._stage_sa(port)
+            else:
+                self._stage_st(port)
             return
-        next_dir = None
-        dx, dy = dst_coords[0] - self.x, dst_coords[1] - self.y
-        if dx != 0:
-            next_dir = 'E' if dx > 0 else 'W'
-        elif dy != 0:
-            next_dir = 'S' if dy > 0 else 'N'
+
+        # normal incoming packet
+        port = event.payload.get("input_port", 0)
+        vc = event.payload.get("vc", 0)
+        self.input_buffers[port][vc].append(event)
+        self._schedule_port(port)
+
+    # ------------------------------------------------------------------
+    # pipeline stage implementations
+    def _select_vc(self, port):
+        for i in range(self.num_vcs):
+            idx = (self.input_rr[port] + i) % self.num_vcs
+            if self.input_buffers[port][idx]:
+                self.input_rr[port] = (idx + 1) % self.num_vcs
+                return idx
+        return None
+
+    def _stage_rc(self, port):
+        if self.port_current_event[port] is None:
+            vc = self._select_vc(port)
+            if vc is None:
+                return  # nothing to process
+            event = self.input_buffers[port][vc][0]
+            self.port_current_event[port] = event
+            self.port_current_vc[port] = vc
         else:
-            raise Exception("Routing error: 목적지에 도달했으나 좌표가 다름")
-        next_router = self.neighbors[next_dir]
-        data_bits = 8 * event.data_size
-        xfer_latency = (data_bits // self.bitwidth) + self.pipeline_delay
-        new_event = Event(
-            src=self,
-            dst=next_router,
-            cycle=self.engine.current_cycle + xfer_latency,
-            data_size=event.data_size,
-            identifier=event.identifier,
-            event_type=event.event_type,
-            payload=event.payload
-        )
+            event = self.port_current_event[port]
+            vc = self.port_current_vc[port]
+
+        dst_coords = event.payload.get("dst_coords")
+        if dst_coords is None:
+            raise ValueError(f"[{self.name}] dst_coords missing in payload")
+        if (self.x, self.y) == tuple(dst_coords):
+            direction = "LOCAL"
+        else:
+            dx = dst_coords[0] - self.x
+            dy = dst_coords[1] - self.y
+            if dx != 0:
+                direction = "E" if dx > 0 else "W"
+            elif dy != 0:
+                direction = "S" if dy > 0 else "N"
+            else:
+                direction = "LOCAL"
+        out_port = DIR_INDEX[direction]
+        event.payload["out_port"] = out_port
+
+        self.port_stage[port] = 1
+        self._schedule_port(port)
+
+    def _stage_va(self, port):
+        event = self.port_current_event[port]
+        if event is None:
+            self.port_stage[port] = 0
+            return
+        out_port = event.payload["out_port"]
+        selected_vc = None
+        for i in range(self.num_vcs):
+            vc_idx = (self.vc_rr[out_port] + i) % self.num_vcs
+            if self.output_vc_allocation[out_port][vc_idx] is not None:
+                continue
+            dest, dest_port = self.output_links[out_port] if out_port < len(self.output_links) else (None, None)
+            if isinstance(dest, Router):
+                if dest.buffer_counts[dest_port][vc_idx] >= dest.buffer_capacity:
+                    continue
+            selected_vc = vc_idx
+            break
+        if selected_vc is None:
+            self._schedule_port(port)
+            return  # stall
+        self.output_vc_allocation[out_port][selected_vc] = port
+        self.vc_rr[out_port] = (selected_vc + 1) % self.num_vcs
+        event.payload["out_vc"] = selected_vc
+        self.port_stage[port] = 2
+        self._schedule_port(port)
+
+    def _stage_sa(self, port):
+        event = self.port_current_event[port]
+        if event is None:
+            self.port_stage[port] = 0
+            return
+        out_port = event.payload["out_port"]
+        if self.crossbar_busy[out_port]:
+            self._schedule_port(port)
+            return  # stall
+        self.crossbar_busy[out_port] = True
+        self.port_stage[port] = 3
+        self._schedule_port(port)
+
+    def _stage_st(self, port):
+        event = self.port_current_event[port]
+        vc = self.port_current_vc[port]
+        out_port = event.payload["out_port"]
+        out_vc = event.payload["out_vc"]
+
+        dest, dest_port = self.output_links[out_port]
+        # prepare payload for next hop
+        event.payload["input_port"] = dest_port if dest_port is not None else 0
+        event.payload["vc"] = out_vc
+
+        new_event = Event(src=self, dst=dest,
+                          cycle=self.engine.current_cycle + 1,
+                          data_size=event.data_size,
+                          identifier=event.identifier,
+                          event_type=event.event_type,
+                          payload=event.payload)
         self.send_event(new_event)
+
+        # remove from buffer and release resources
+        self.input_buffers[port][vc].pop(0)
+        self._release_slot({"input_port": port, "vc": vc})
+        self.output_vc_allocation[out_port][out_vc] = None
+        self.crossbar_busy[out_port] = False
+
+        self.port_current_event[port] = None
+        self.port_current_vc[port] = None
+        self.port_stage[port] = 0
+        if any(self.input_buffers[port][i] for i in range(self.num_vcs)):
+            self._schedule_port(port)

--- a/sim_hw/__init__.py
+++ b/sim_hw/__init__.py
@@ -1,0 +1,1 @@
+from .traffic_gen import TrafficGenerator

--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -35,6 +35,8 @@ class ControlProcessor(HardwareModule):
                         "data_size": state["weights_size"] + state["act_size"],
                         "src_name": self.name,
                         "need_reply": True,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(dma_evt)
@@ -59,6 +61,8 @@ class ControlProcessor(HardwareModule):
                             "gemm_shape": state["gemm_shape"],
                             "src_name": self.name,
                             "need_reply": True,
+                            "input_port": 0,
+                            "vc": 0,
                         },
                     )
                     self.send_event(gemm_evt)
@@ -124,6 +128,8 @@ class ControlProcessor(HardwareModule):
                         "src_name": self.name,
                         "need_reply": True,
                         "task_cycles": state["dram_cycles"],
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(dma_evt)
@@ -148,6 +154,8 @@ class ControlProcessor(HardwareModule):
                             "task_cycles": state["task_cycles"],
                             "src_name": self.name,
                             "need_reply": True,
+                            "input_port": 0,
+                            "vc": 0,
                         },
                     )
                     self.send_event(cmd_evt)
@@ -173,6 +181,8 @@ class ControlProcessor(HardwareModule):
                             "src_name": self.name,
                             "need_reply": True,
                             "task_cycles": state["dram_cycles"],
+                            "input_port": 0,
+                            "vc": 0,
                         },
                     )
                     self.send_event(dma_evt)

--- a/sim_hw/dram.py
+++ b/sim_hw/dram.py
@@ -48,6 +48,8 @@ class DRAM(PipelineModule):
                 event_type=evt_type,
                 payload={
                     "dst_coords": coords,
+                    "input_port": 0,
+                    "vc": 0,
                 },
             )
             self.send_event(reply_event)

--- a/sim_hw/npu.py
+++ b/sim_hw/npu.py
@@ -39,6 +39,8 @@ class NPU(PipelineModule):
                 payload={
                     "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                     "npu_name": self.name,
+                    "input_port": 0,
+                    "vc": 0,
                 },
             )
             self.send_event(evt)
@@ -66,6 +68,8 @@ class NPU(PipelineModule):
                         "src_name": self.name,
                         "need_reply": True,
                         "task_cycles": event.payload.get("task_cycles", 5),
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(read_evt)
@@ -82,6 +86,8 @@ class NPU(PipelineModule):
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                         "npu_name": self.name,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(done_evt)
@@ -113,6 +119,8 @@ class NPU(PipelineModule):
                         "src_name": self.name,
                         "need_reply": True,
                         "task_cycles": event.payload.get("task_cycles", 5),
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(wr_evt)
@@ -129,6 +137,8 @@ class NPU(PipelineModule):
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                         "npu_name": self.name,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(done_evt)

--- a/sim_hw/pe.py
+++ b/sim_hw/pe.py
@@ -45,6 +45,8 @@ class PE(PipelineModule):
                 payload={
                     "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                     "pe_name": self.name,
+                    "input_port": 0,
+                    "vc": 0,
                 },
             )
             self.send_event(evt)
@@ -71,6 +73,8 @@ class PE(PipelineModule):
                         "dst_coords": dram_coords,
                         "src_name": self.name,
                         "need_reply": True,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(read_evt)
@@ -87,6 +91,8 @@ class PE(PipelineModule):
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                         "pe_name": self.name,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(done_evt)
@@ -118,6 +124,8 @@ class PE(PipelineModule):
                         "dst_coords": dram_coords,
                         "src_name": self.name,
                         "need_reply": True,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(wr_evt)
@@ -134,6 +142,8 @@ class PE(PipelineModule):
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
                         "pe_name": self.name,
+                        "input_port": 0,
+                        "vc": 0,
                     },
                 )
                 self.send_event(done_evt)

--- a/sim_hw/traffic_gen.py
+++ b/sim_hw/traffic_gen.py
@@ -1,0 +1,49 @@
+from sim_core.module import HardwareModule
+from sim_core.event import Event
+import random
+
+class TrafficGenerator(HardwareModule):
+    """Generates uniform random traffic and records latency."""
+    def __init__(self, engine, name, mesh_info, coords, num_packets=10, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
+        self.coords = coords
+        self.num_packets = num_packets
+        self.sent = 0
+        self.received = 0
+        self.latencies = []
+
+    def start(self):
+        evt = Event(src=self, dst=self, cycle=self.engine.current_cycle + 1,
+                    event_type="GENERATE")
+        self.engine.push_event(evt)
+
+    def get_my_router(self):
+        return self.mesh_info["router_map"][self.coords]
+
+    def handle_event(self, event):
+        if event.event_type == "GENERATE":
+            if self.sent < self.num_packets:
+                x_max, y_max = self.mesh_info["mesh_size"]
+                dst = (random.randrange(x_max), random.randrange(y_max))
+                payload = {
+                    "dst_coords": dst,
+                    "start_cycle": self.engine.current_cycle,
+                    "input_port": 0,
+                    "vc": 0,
+                }
+                pkt = Event(src=self, dst=self.get_my_router(),
+                             cycle=self.engine.current_cycle,
+                             data_size=1, event_type="PACKET",
+                             payload=payload)
+                self.send_event(pkt)
+                self.sent += 1
+            if self.sent < self.num_packets:
+                nxt = Event(src=self, dst=self, cycle=self.engine.current_cycle + 1,
+                            event_type="GENERATE")
+                self.engine.push_event(nxt)
+        elif event.event_type == "PACKET":
+            latency = self.engine.current_cycle - event.payload.get("start_cycle", 0)
+            self.latencies.append(latency)
+            self.received += 1
+        else:
+            super().handle_event(event)

--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -24,15 +24,15 @@ class NPUTest(unittest.TestCase):
         npu = NPU(engine, "NPU_0", mesh_info, buffer_capacity=1)
         mesh_info["npu_coords"]["NPU_0"] = (0,0)
         mesh_info["pe_coords"]["NPU_0"] = (0,0)
-        mesh[(0,0)].attached_module = npu
+        mesh[(0,0)].attach_module(npu)
         engine.register_module(npu)
         dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
-        mesh[(1,0)].attached_module = dram
+        mesh[(1,0)].attach_module(dram)
         engine.register_module(dram)
         cp = ControlProcessor(engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1)
         mesh_info["cp_coords"]["CP"] = (2,0)
-        mesh[(2,0)].attached_module = cp
+        mesh[(2,0)].attach_module(cp)
         engine.register_module(cp)
 
         event = Event(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,15 +22,15 @@ class PipelineSimTest(unittest.TestCase):
         mesh_info["router_map"] = mesh
         pe = PE(engine, "PE_0", mesh_info, buffer_capacity=1)
         mesh_info["pe_coords"]["PE_0"] = (0,0)
-        mesh[(0,0)].attached_module = pe
+        mesh[(0,0)].attach_module(pe)
         engine.register_module(pe)
         dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
-        mesh[(1,0)].attached_module = dram
+        mesh[(1,0)].attach_module(dram)
         engine.register_module(dram)
         cp = ControlProcessor(engine, "CP", mesh_info, [pe], dram, buffer_capacity=1)
         mesh_info["cp_coords"]["CP"] = (2,0)
-        mesh[(2,0)].attached_module = cp
+        mesh[(2,0)].attach_module(cp)
         engine.register_module(cp)
 
         gemm_shape = (2,2,2)

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -1,0 +1,12 @@
+import unittest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from examples.uniform_traffic import run_uniform_traffic
+
+class TrafficTest(unittest.TestCase):
+    def test_uniform(self):
+        avg = run_uniform_traffic(x=16, y=16, packets_per_node=5, max_tick=10000)
+        self.assertGreaterEqual(avg, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement new high-radix router supporting virtual channels and a 4-stage pipeline
- propagate port and VC information in all module-to-router packets
- connect attached modules using `attach_module`
- expose `num_vcs` in `create_mesh`
- add uniform random traffic generator and example
- document VC router and traffic example

## Testing
- `pip install torch torchvision torchaudio`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686218d9e5ac8330aba78c8fe8e5b0d9