### PR TITLE
Add sync status tracking for NPU commands

### DIFF
--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -52,6 +52,9 @@ class NPUTest(unittest.TestCase):
         engine.run_until_idle(max_tick=500)
         self.assertEqual(len(engine.event_queue), 0)
         self.assertFalse(cp.active_npu_tasks)
+        self.assertTrue(cp.npu_dma_in_sync_done.get("npu_task"))
+        self.assertTrue(cp.npu_cmd_sync_done.get("npu_task"))
+        self.assertTrue(cp.npu_dma_out_sync_done.get("npu_task"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expose DMA_IN/CMD/DMA_OUT synchronization status in `ControlProcessor`
- clear status when a new task starts
- validate status flags in NPU flow test

## Testing
- `pip install torch torchvision torchaudio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686350891c048330bd8e2145d500ae7e