### PR TITLE
Rename task variables to program/opcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,26 +64,32 @@ from sim_core.event import Event
 
 # Schedule the DMA input
 cp.send_event(Event(
-    src=None, dst=cp, cycle=1, identifier="task0", event_type="NPU_DMA_IN",
-    payload={"task_cycles":3, "in_size":16, "out_size":16, "dram_cycles":2}
+    src=None, dst=cp, cycle=1, program="prog0", event_type="NPU_DMA_IN",
+    payload={"program_cycles":3, "in_size":16, "out_size":16,
+            "dma_in_opcode_cycles":2, "dma_out_opcode_cycles":2,
+            "cmd_opcode_cycles":3}
 ))
 
 # Compute waits for DMA_IN completion of NPU_0
 cp.send_event(Event(
-    src=None, dst=cp, cycle=1, identifier="task0", event_type="NPU_CMD",
-    payload={"task_cycles":3, "sync_type":0, "sync_targets":["NPU_0"]}
+    src=None, dst=cp, cycle=1, program="prog0", event_type="NPU_CMD",
+    payload={"program_cycles":3, "in_size":16, "out_size":16,
+            "dma_in_opcode_cycles":2, "dma_out_opcode_cycles":2,
+            "cmd_opcode_cycles":3, "sync_type":0, "sync_targets":["NPU_0"]}
 ))
 
 # DMA_OUT waits for the CMD phase to finish
 cp.send_event(Event(
-    src=None, dst=cp, cycle=1, identifier="task0", event_type="NPU_DMA_OUT",
-    payload={"task_cycles":3, "sync_type":1, "sync_targets":["NPU_0"]}
+    src=None, dst=cp, cycle=1, program="prog0", event_type="NPU_DMA_OUT",
+    payload={"program_cycles":3, "in_size":16, "out_size":16,
+            "dma_in_opcode_cycles":2, "dma_out_opcode_cycles":2,
+            "cmd_opcode_cycles":3, "sync_type":1, "sync_targets":["NPU_0"]}
 ))
 
 engine.run_until_idle()
 ```
 
-After the engine idles you can query `cp.npu_dma_in_sync_done['task0']`, `cp.npu_cmd_sync_done['task0']` and `cp.npu_dma_out_sync_done['task0']` to confirm each phase finished.
+After the engine idles you can query `cp.npu_dma_in_opcode_done['prog0']`, `cp.npu_cmd_opcode_done['prog0']` and `cp.npu_dma_out_opcode_done['prog0']` to confirm each phase finished.
 
 
 ## Uniform Traffic Example

--- a/sim_core/event.py
+++ b/sim_core/event.py
@@ -1,13 +1,13 @@
 class Event:
     """Discrete event object used by :class:`SimulatorEngine`."""
 
-    def __init__(self, src, dst, cycle, data_size=0, identifier=None,
+    def __init__(self, src, dst, cycle, data_size=0, program=None,
                  event_type=None, payload=None, priority=0):
         self.src = src
         self.dst = dst
         self.cycle = cycle
         self.data_size = data_size
-        self.identifier = identifier
+        self.program = program
         self.event_type = event_type
         self.payload = payload or {}
         # ``priority`` is used to break ties between events scheduled for the

--- a/sim_core/router.py
+++ b/sim_core/router.py
@@ -217,7 +217,7 @@ class Router(PipelineModule):
         new_event = Event(src=self, dst=dest,
                           cycle=self.engine.current_cycle + 1,
                           data_size=event.data_size,
-                          identifier=event.identifier,
+                          program=event.program,
                           event_type=event.event_type,
                           payload=event.payload)
         self.send_event(new_event)

--- a/sim_hw/pe.py
+++ b/sim_hw/pe.py
@@ -13,7 +13,7 @@ class PE(PipelineModule):
         self.received_dma_writes = {}
         self.gemm_cycles_remaining = 0
         self.gemm_total_cycles = 0
-        self.gemm_identifier = None
+        self.gemm_program = None
         self.cp_name = None
         funcs = [self._make_stage_func(i) for i in range(pipeline_stages)]
         self.set_stage_funcs(funcs)
@@ -40,7 +40,7 @@ class PE(PipelineModule):
                 dst=self.get_my_router(),
                 cycle=self.engine.current_cycle,
                 data_size=4,
-                identifier=self.gemm_identifier,
+                program=self.gemm_program,
                 event_type="PE_GEMM_DONE",
                 payload={
                     "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
@@ -51,14 +51,14 @@ class PE(PipelineModule):
             )
             self.send_event(evt)
             self.gemm_total_cycles = 0
-            self.gemm_identifier = None
+            self.gemm_program = None
             self.cp_name = None
 
     def handle_event(self, event):
         if event.event_type == "PE_DMA_IN":
             total = event.payload["data_size"] // 4
-            self.expected_dma_reads[event.identifier] = total
-            self.received_dma_reads[event.identifier] = 0
+            self.expected_dma_reads[event.program] = total
+            self.received_dma_reads[event.program] = 0
             self.cp_name = event.payload["src_name"]
             dram_coords = list(self.mesh_info["dram_coords"].values())[0]
             for i in range(total):
@@ -67,7 +67,7 @@ class PE(PipelineModule):
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle + i,
                     data_size=4,
-                    identifier=event.identifier,
+                    program=event.program,
                     event_type="DMA_READ",
                     payload={
                         "dst_coords": dram_coords,
@@ -79,14 +79,14 @@ class PE(PipelineModule):
                 )
                 self.send_event(read_evt)
         elif event.event_type == "DMA_READ_REPLY":
-            self.received_dma_reads[event.identifier] += 1
-            if self.received_dma_reads[event.identifier] >= self.expected_dma_reads[event.identifier]:
+            self.received_dma_reads[event.program] += 1
+            if self.received_dma_reads[event.program] >= self.expected_dma_reads[event.program]:
                 done_evt = Event(
                     src=self,
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle,
                     data_size=4,
-                    identifier=event.identifier,
+                    program=event.program,
                     event_type="PE_DMA_IN_DONE",
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
@@ -96,20 +96,20 @@ class PE(PipelineModule):
                     },
                 )
                 self.send_event(done_evt)
-                del self.expected_dma_reads[event.identifier]
-                del self.received_dma_reads[event.identifier]
+                del self.expected_dma_reads[event.program]
+                del self.received_dma_reads[event.program]
         elif event.event_type == "PE_GEMM":
             M, N, K = event.payload["gemm_shape"]
             cycles = (M * N * K + self.mac_units - 1) // self.mac_units
             self.gemm_cycles_remaining = cycles
             self.gemm_total_cycles = cycles
-            self.gemm_identifier = event.identifier
+            self.gemm_program = event.program
             self.cp_name = event.payload["src_name"]
             self._schedule_stage(0)
         elif event.event_type == "PE_DMA_OUT":
             total = event.payload["data_size"] // 4
-            self.expected_dma_writes[event.identifier] = total
-            self.received_dma_writes[event.identifier] = 0
+            self.expected_dma_writes[event.program] = total
+            self.received_dma_writes[event.program] = 0
             self.cp_name = event.payload["src_name"]
             dram_coords = list(self.mesh_info["dram_coords"].values())[0]
             for i in range(total):
@@ -118,7 +118,7 @@ class PE(PipelineModule):
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle + i,
                     data_size=4,
-                    identifier=event.identifier,
+                    program=event.program,
                     event_type="DMA_WRITE",
                     payload={
                         "dst_coords": dram_coords,
@@ -130,14 +130,14 @@ class PE(PipelineModule):
                 )
                 self.send_event(wr_evt)
         elif event.event_type == "WRITE_REPLY":
-            self.received_dma_writes[event.identifier] += 1
-            if self.received_dma_writes[event.identifier] >= self.expected_dma_writes[event.identifier]:
+            self.received_dma_writes[event.program] += 1
+            if self.received_dma_writes[event.program] >= self.expected_dma_writes[event.program]:
                 done_evt = Event(
                     src=self,
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle,
                     data_size=4,
-                    identifier=event.identifier,
+                    program=event.program,
                     event_type="PE_DMA_OUT_DONE",
                     payload={
                         "dst_coords": self.mesh_info["cp_coords"][self.cp_name],
@@ -147,8 +147,8 @@ class PE(PipelineModule):
                     },
                 )
                 self.send_event(done_evt)
-                del self.expected_dma_writes[event.identifier]
-                del self.received_dma_writes[event.identifier]
+                del self.expected_dma_writes[event.program]
+                del self.received_dma_writes[event.program]
         else:
             super().handle_event(event)
 

--- a/sim_ml/llama3_sim_hook.py
+++ b/sim_ml/llama3_sim_hook.py
@@ -14,7 +14,7 @@ def linear_gemm_hook(cp, mesh_info):
             src=None,
             dst=cp,
             cycle=cp.engine.current_cycle + 1,
-            identifier=f"Linear_GEMM_{module.sim_layer_idx}",
+            program=f"Linear_GEMM_{module.sim_layer_idx}",
             event_type="GEMM",
             payload={
                 "gemm_shape": gemm_shape,

--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -35,18 +35,22 @@ class NPUTest(unittest.TestCase):
         mesh[(2,0)].attach_module(cp)
         engine.register_module(cp)
 
+        program_cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+
         dma_in_evt = Event(
             src=None,
             dst=cp,
             cycle=1,
-            identifier="npu_task",
+            program="npu_prog",
             event_type="NPU_DMA_IN",
-            payload={
-                "task_cycles": 3,
-                "in_size": 16,
-                "out_size": 16,
-                "dram_cycles": 2,
-            },
+            payload=program_cfg,
         )
         cp.send_event(dma_in_evt)
 
@@ -54,13 +58,10 @@ class NPUTest(unittest.TestCase):
             src=None,
             dst=cp,
             cycle=engine.current_cycle,
-            identifier="npu_task",
+            program="npu_prog",
             event_type="NPU_CMD",
             payload={
-                "task_cycles": 3,
-                "in_size": 16,
-                "out_size": 16,
-                "dram_cycles": 2,
+                **program_cfg,
                 "sync_type": 0,
                 "sync_targets": ["NPU_0"],
             },
@@ -71,13 +72,10 @@ class NPUTest(unittest.TestCase):
             src=None,
             dst=cp,
             cycle=engine.current_cycle,
-            identifier="npu_task",
+            program="npu_prog",
             event_type="NPU_DMA_OUT",
             payload={
-                "task_cycles": 3,
-                "in_size": 16,
-                "out_size": 16,
-                "dram_cycles": 2,
+                **program_cfg,
                 "sync_type": 1,
                 "sync_targets": ["NPU_0"],
             },
@@ -85,11 +83,11 @@ class NPUTest(unittest.TestCase):
         cp.send_event(out_evt)
 
         engine.run_until_idle(max_tick=500)
-        self.assertTrue(cp.npu_dma_in_sync_done.get("npu_task"))
-        self.assertTrue(cp.npu_cmd_sync_done.get("npu_task"))
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("npu_prog"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("npu_prog"))
         self.assertEqual(len(engine.event_queue), 0)
-        self.assertFalse(cp.active_npu_tasks)
-        self.assertTrue(cp.npu_dma_out_sync_done.get("npu_task"))
+        self.assertFalse(cp.active_npu_programs)
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("npu_prog"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,7 +38,7 @@ class PipelineSimTest(unittest.TestCase):
             src=None,
             dst=cp,
             cycle=1,
-            identifier="test_gemm",
+            program="test_gemm",
             event_type="GEMM",
             payload={
                 "gemm_shape": gemm_shape,


### PR DESCRIPTION
## Summary
- replace `identifier` with `program` on `Event`
- rename CP's NPU task handling to use program terminology
- update DRAM, PE and NPU modules for opcode-centric naming
- adjust tests and docs for new APIs
- rename program phase done flags to `*_opcode_done`

## Testing
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6864e18816bc83308dbe4b92f7ea17e5