### PR TITLE
Introduce CP sync events

### DIFF
--- a/sim_core/engine.py
+++ b/sim_core/engine.py
@@ -19,11 +19,39 @@ class SimulatorEngine:
     
     def tick(self):
         self.current_cycle += 1
-        events_to_handle = []
+        sync_map = {
+            "NPU_DMA_IN_SYNC": 0,
+            "NPU_CMD_SYNC": 1,
+            "NPU_DMA_OUT_SYNC": 2,
+        }
+
         while self.event_queue and self.event_queue[0].cycle <= self.current_cycle:
             event = heapq.heappop(self.event_queue)
-            events_to_handle.append(event)
-        for event in events_to_handle:
+
+            if event.event_type in sync_map:
+                cp = event.dst
+                sync_type = sync_map[event.event_type]
+                targets = event.payload.get("sync_targets")
+                if not cp._is_sync_ready(event.program, sync_type, targets):
+                    event.cycle += 1
+                    heapq.heappush(self.event_queue, event)
+
+                    # Delay any other pending events destined for the same CP this cycle
+                    temp = []
+                    while self.event_queue and self.event_queue[0].cycle <= self.current_cycle:
+                        nxt = heapq.heappop(self.event_queue)
+                        if nxt.dst is cp and nxt.event_type not in (
+                            "RETRY_SEND",
+                            "NPU_DMA_IN_DONE",
+                            "NPU_CMD_DONE",
+                            "NPU_DMA_OUT_DONE",
+                        ):
+                            nxt.cycle += 1
+                        temp.append(nxt)
+                    for nxt in temp:
+                        heapq.heappush(self.event_queue, nxt)
+                    continue
+
             event.handle()
 
     def run_until_idle(self, max_tick=None):

--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -51,36 +51,64 @@ class NPUTest(unittest.TestCase):
             program="npu_prog",
             event_type="NPU_DMA_IN",
             payload=program_cfg,
+            priority=-1,
         )
         cp.send_event(dma_in_evt)
+
+        dma_in_sync = Event(
+            src=None,
+            dst=cp,
+            cycle=1,
+            program="npu_prog",
+            event_type="NPU_DMA_IN_SYNC",
+            payload={"sync_targets": ["NPU_0"]},
+            priority=0,
+        )
+        cp.send_event(dma_in_sync)
 
         cmd_evt = Event(
             src=None,
             dst=cp,
-            cycle=engine.current_cycle,
+            cycle=1,
             program="npu_prog",
             event_type="NPU_CMD",
-            payload={
-                **program_cfg,
-                "sync_type": 0,
-                "sync_targets": ["NPU_0"],
-            },
+            payload=program_cfg,
+            priority=1,
         )
         cp.send_event(cmd_evt)
+
+        cmd_sync = Event(
+            src=None,
+            dst=cp,
+            cycle=1,
+            program="npu_prog",
+            event_type="NPU_CMD_SYNC",
+            payload={"sync_targets": ["NPU_0"]},
+            priority=2,
+        )
+        cp.send_event(cmd_sync)
 
         out_evt = Event(
             src=None,
             dst=cp,
-            cycle=engine.current_cycle,
+            cycle=1,
             program="npu_prog",
             event_type="NPU_DMA_OUT",
-            payload={
-                **program_cfg,
-                "sync_type": 1,
-                "sync_targets": ["NPU_0"],
-            },
+            payload=program_cfg,
+            priority=3,
         )
         cp.send_event(out_evt)
+
+        out_sync = Event(
+            src=None,
+            dst=cp,
+            cycle=1,
+            program="npu_prog",
+            event_type="NPU_DMA_OUT_SYNC",
+            payload={"sync_targets": ["NPU_0"]},
+            priority=4,
+        )
+        cp.send_event(out_sync)
 
         engine.run_until_idle(max_tick=500)
         self.assertTrue(cp.npu_dma_in_opcode_done.get("npu_prog"))


### PR DESCRIPTION
## Summary
- add sync event gating in `SimulatorEngine`
- handle dedicated CP sync events in `ControlProcessor`
- update NPU flow test for new sync workflow
- document sync event usage

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68673ad1a2288330ad5bbd9252c7bf0a