### PR TITLE
Add flexible NPU programs

### DIFF
--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -295,73 +295,73 @@ class ControlProcessor(HardwareModule):
 
         elif event.event_type == "NPU_DMA_IN_DONE":
             prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
             npu_name = event.payload["npu_name"]
-            prog_state["waiting_dma_in"].discard(npu_name)
-            if not prog_state["waiting_dma_in"]:
-                # Mark completion so external modules can trigger the next phase
-                self.npu_dma_in_opcode_done[event.program] = True
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "dma_in" in wait["types"]:
-                    wait["types"].discard("dma_in")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            if prog_state:
+                prog_state["waiting_dma_in"].discard(npu_name)
+                if prog_state["waiting_dma_in"]:
+                    return
+            # Mark completion so external modules can trigger the next phase
+            self.npu_dma_in_opcode_done[event.program] = True
+            wait = self.npu_sync_wait.get(event.program)
+            if wait and "dma_in" in wait["types"]:
+                wait["types"].discard("dma_in")
+                if not wait["types"]:
+                    wait["release_cycle"] = self.engine.current_cycle
+                    state = self.program_state.get(event.program)
+                    if state:
+                        state["waiting"] = False
+                        resume = Event(src=self, dst=self,
+                                       cycle=self.engine.current_cycle + 1,
+                                       program=event.program,
+                                       event_type="RUN_PROGRAM")
+                        self.engine.push_event(resume)
 
         elif event.event_type == "NPU_CMD_DONE":
             prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
             npu_name = event.payload["npu_name"]
-            prog_state["waiting_op"].discard(npu_name)
-            if not prog_state["waiting_op"]:
-                # Command phase finished
-                self.npu_cmd_opcode_done[event.program] = True
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "cmd" in wait["types"]:
-                    wait["types"].discard("cmd")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            if prog_state:
+                prog_state["waiting_op"].discard(npu_name)
+                if prog_state["waiting_op"]:
+                    return
+            # Command phase finished
+            self.npu_cmd_opcode_done[event.program] = True
+            wait = self.npu_sync_wait.get(event.program)
+            if wait and "cmd" in wait["types"]:
+                wait["types"].discard("cmd")
+                if not wait["types"]:
+                    wait["release_cycle"] = self.engine.current_cycle
+                    state = self.program_state.get(event.program)
+                    if state:
+                        state["waiting"] = False
+                        resume = Event(src=self, dst=self,
+                                       cycle=self.engine.current_cycle + 1,
+                                       program=event.program,
+                                       event_type="RUN_PROGRAM")
+                        self.engine.push_event(resume)
 
         elif event.event_type == "NPU_DMA_OUT_DONE":
             prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
             npu_name = event.payload["npu_name"]
-            prog_state["waiting_dma_out"].discard(npu_name)
-            if not prog_state["waiting_dma_out"]:
-                print(f"[CP] NPU task {event.program} 완료")
-                self.npu_dma_out_opcode_done[event.program] = True
-                self.active_npu_programs.pop(event.program, None)
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "dma_out" in wait["types"]:
-                    wait["types"].discard("dma_out")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            if prog_state:
+                prog_state["waiting_dma_out"].discard(npu_name)
+                if prog_state["waiting_dma_out"]:
+                    return
+            print(f"[CP] NPU task {event.program} 완료")
+            self.npu_dma_out_opcode_done[event.program] = True
+            self.active_npu_programs.pop(event.program, None)
+            wait = self.npu_sync_wait.get(event.program)
+            if wait and "dma_out" in wait["types"]:
+                wait["types"].discard("dma_out")
+                if not wait["types"]:
+                    wait["release_cycle"] = self.engine.current_cycle
+                    state = self.program_state.get(event.program)
+                    if state:
+                        state["waiting"] = False
+                        resume = Event(src=self, dst=self,
+                                       cycle=self.engine.current_cycle + 1,
+                                       program=event.program,
+                                       event_type="RUN_PROGRAM")
+                        self.engine.push_event(resume)
 
         else:
             super().handle_event(event)

--- a/tests/test_npu_extended.py
+++ b/tests/test_npu_extended.py
@@ -1,0 +1,94 @@
+import unittest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sim_core.engine import SimulatorEngine
+from sim_core.mesh import create_mesh
+from sim_core.event import Event
+from sim_hw.cp import ControlProcessor
+from sim_hw.npu import NPU
+from sim_hw.dram import DRAM
+
+
+def setup_env():
+    engine = SimulatorEngine()
+    mesh_info = {
+        "mesh_size": (3, 1),
+        "router_map": None,
+        "npu_coords": {},
+        "pe_coords": {},
+        "cp_coords": {},
+        "dram_coords": {},
+    }
+    mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
+    mesh_info["router_map"] = mesh
+    npu = NPU(engine, "NPU_0", mesh_info, buffer_capacity=1)
+    mesh_info["npu_coords"]["NPU_0"] = (0, 0)
+    mesh_info["pe_coords"]["NPU_0"] = (0, 0)
+    mesh[(0, 0)].attach_module(npu)
+    engine.register_module(npu)
+    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
+    mesh_info["dram_coords"]["DRAM"] = (1, 0)
+    mesh[(1, 0)].attach_module(dram)
+    engine.register_module(dram)
+    cp = ControlProcessor(engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1)
+    mesh_info["cp_coords"]["CP"] = (2, 0)
+    mesh[(2, 0)].attach_module(cp)
+    engine.register_module(cp)
+    return engine, cp
+
+
+class NPUExtendedTest(unittest.TestCase):
+    def test_multiple_dma_in(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+            {"event_type": "NPU_CMD", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["cmd"]}},
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+            {"event_type": "NPU_CMD", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["cmd"]}},
+        ]
+        cp.load_program("prog_multi", instrs)
+        cp.send_event(Event(src=None, dst=cp, cycle=1, program="prog_multi", event_type="RUN_PROGRAM"))
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_multi"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("prog_multi"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_multi"))
+        self.assertEqual(len(engine.event_queue), 0)
+
+    def test_concurrent_dma_in_out(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_DMA_OUT", "payload": cfg},
+        ]
+        cp.load_program("prog_concurrent", instrs)
+        cp.send_event(Event(src=None, dst=cp, cycle=1, program="prog_concurrent", event_type="RUN_PROGRAM"))
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_concurrent"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_concurrent"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("prog_concurrent"))
+        self.assertEqual(len(engine.event_queue), 0)
+        self.assertFalse(cp.active_npu_programs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support DONE events even if program state was removed
- add new tests for multiple DMA_IN calls and concurrent DMA_IN/OUT

## Testing
- `python -m unittest discover tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68678da8b0088330ba6aef7e30361ea5