### PR TITLE
Add opcode flag init during load

### DIFF
--- a/sim_core/module.py
+++ b/sim_core/module.py
@@ -26,8 +26,14 @@ class HardwareModule:
     def _process_event(self, event):
         try:
             if self.engine.logger:
-                stage = event.payload.get('stage_idx', 0) if isinstance(event.payload, dict) else 0
-                self.engine.logger.log_event(self.engine.current_cycle, self.name, stage, event.event_type)
+                stage = (
+                    event.payload.get("stage_idx", 0)
+                    if isinstance(event.payload, dict)
+                    else 0
+                )
+                self.engine.logger.log_event(
+                    self.engine.current_cycle, self.name, stage, event.event_type
+                )
             self.handle_event(event)
         finally:
             self._release_slot(event)
@@ -42,8 +48,13 @@ class HardwareModule:
             # Destination buffer full; stall and retry next cycle
             if hasattr(self, "set_stall"):
                 self.set_stall(1)
-            retry = Event(src=self, dst=self, cycle=self.engine.current_cycle + 1,
-                           event_type="RETRY_SEND", payload={"event": event})
+            retry = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                event_type="RETRY_SEND",
+                payload={"event": event},
+            )
             self.engine.push_event(retry)
         else:
             self.engine.push_event(event)
@@ -55,8 +66,7 @@ class PipelineModule(HardwareModule):
     def __init__(self, engine, name, mesh_info, num_stages, buffer_capacity=4):
         super().__init__(engine, name, mesh_info, buffer_capacity)
         self.num_stages = num_stages
-        self.stage_funcs = [lambda m, d: (d, i + 1, False)
-                           for i in range(num_stages)]
+        self.stage_funcs = [lambda m, d: (d, i + 1, False) for i in range(num_stages)]
         self.stage_queues = [list() for _ in range(num_stages)]
         self.stage_scheduled = [False for _ in range(num_stages)]
         self.stage_capacity = buffer_capacity
@@ -74,12 +84,14 @@ class PipelineModule(HardwareModule):
 
     def _schedule_stage(self, idx):
         if not self.stage_scheduled[idx]:
-            evt = Event(src=self,
-                        dst=self,
-                        cycle=self.engine.current_cycle + 1,
-                        event_type="PIPE_STAGE",
-                        payload={"stage_idx": idx},
-                        priority=-idx)
+            evt = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                event_type="PIPE_STAGE",
+                payload={"stage_idx": idx},
+                priority=-idx,
+            )
             self.send_event(evt)
             self.stage_scheduled[idx] = True
 
@@ -110,7 +122,10 @@ class PipelineModule(HardwareModule):
             self._schedule_stage(idx)
             return
 
-        if next_stage < self.num_stages and len(self.stage_queues[next_stage]) >= self.stage_capacity:
+        if (
+            next_stage < self.num_stages
+            and len(self.stage_queues[next_stage]) >= self.stage_capacity
+        ):
             # downstream stage full - retry later
             self._schedule_stage(idx)
             return
@@ -128,3 +143,75 @@ class PipelineModule(HardwareModule):
 
     def handle_pipeline_output(self, data):
         pass
+
+
+class SyncModule(HardwareModule):
+    """Mixin providing synchronization utilities for *_SYNC instructions."""
+
+    def __init__(self, engine, name, mesh_info, buffer_capacity=4):
+        super().__init__(engine, name, mesh_info, buffer_capacity)
+        # Map program -> {"types": set(str), "release_cycle": int}
+        self.sync_wait = {}
+
+    def gate_by_sync(self, event, allowed=()):
+        """Return True if the event should be retried due to an active sync."""
+        wait = self.sync_wait.get(event.program)
+        if not wait:
+            return False
+
+        if event.event_type not in allowed and (
+            wait["types"] or wait.get("release_cycle") == self.engine.current_cycle
+        ):
+            retry_evt = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                program=event.program,
+                event_type=event.event_type,
+                payload=event.payload,
+                data_size=getattr(event, "data_size", 0),
+            )
+            self.send_event(retry_evt)
+            return True
+
+        if (
+            not wait["types"]
+            and wait.get("release_cycle", -1) < self.engine.current_cycle
+        ):
+            del self.sync_wait[event.program]
+        return False
+
+    def process_phase_done(
+        self,
+        program,
+        actor,
+        active_states,
+        waiting_field,
+        done_dict,
+        wait_type,
+        resume_fn,
+    ):
+        """Common logic for handling *_DONE events under synchronization."""
+        state = active_states.get(program)
+        if state:
+            state[waiting_field].discard(actor)
+            if state[waiting_field]:
+                return False
+
+        done_dict[program] = True
+
+        wait = self.sync_wait.get(program)
+        should_resume = False
+        if wait and wait_type in wait["types"]:
+            wait["types"].discard(wait_type)
+            if not wait["types"]:
+                wait["release_cycle"] = self.engine.current_cycle
+                should_resume = True
+        else:
+            # No sync for this phase; still resume so RUN_PROGRAM can check
+            should_resume = True
+
+        if should_resume:
+            resume_fn()
+
+        return True

--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -1,8 +1,11 @@
-from sim_core.module import HardwareModule
+from sim_core.module import SyncModule
 from sim_core.event import Event
 
-class ControlProcessor(HardwareModule):
-    def __init__(self, engine, name, mesh_info, pes, dram, npus=None, buffer_capacity=4):
+
+class ControlProcessor(SyncModule):
+    def __init__(
+        self, engine, name, mesh_info, pes, dram, npus=None, buffer_capacity=4
+    ):
         super().__init__(engine, name, mesh_info, buffer_capacity)
         self.pes = pes
         self.npus = npus or []
@@ -19,10 +22,26 @@ class ControlProcessor(HardwareModule):
         # was released.  We keep the entry around for one extra cycle so that
         # events scheduled in the same cycle as the *_DONE that released the
         # sync are still blocked.
-        self.npu_sync_wait = {}
+        # synchronization tracking for NPU operations
+        self.npu_sync_wait = self.sync_wait
         # Store control programs and per-program execution state
         self.program_store = {}
         self.program_state = {}
+        # Pre-created NPU program templates
+        self.npu_program_templates = {}
+
+    def _resume_program(self, program):
+        state = self.program_state.get(program)
+        if state:
+            state["waiting"] = False
+            resume = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                program=program,
+                event_type="RUN_PROGRAM",
+            )
+            self.engine.push_event(resume)
 
     def _create_program_state(self, payload):
         return {
@@ -34,80 +53,106 @@ class ControlProcessor(HardwareModule):
             "out_size": payload["out_size"],
             "dma_in_opcode_cycles": payload.get("dma_in_opcode_cycles", 5),
             "dma_out_opcode_cycles": payload.get("dma_out_opcode_cycles", 5),
-            "cmd_opcode_cycles": payload.get("cmd_opcode_cycles", payload["program_cycles"]),
+            "cmd_opcode_cycles": payload.get(
+                "cmd_opcode_cycles", payload["program_cycles"]
+            ),
         }
 
     def load_program(self, name, instructions):
         """Register a list of instructions for sequential execution."""
         self.program_store[name] = instructions
         self.program_state[name] = {"pc": 0, "waiting": False}
+        cfg = None
+        for instr in instructions:
+            payload = instr.get("payload")
+            if isinstance(payload, dict) and "program_cycles" in payload:
+                cfg = payload
+                break
+        if cfg:
+            tmpl = self._create_program_state(cfg)
+            self.npu_program_templates[name] = {
+                k: set(v) if isinstance(v, set) else v for k, v in tmpl.items()
+            }
+            # Pre-register active state so DMA handlers assume existence
+            self.active_npu_programs[name] = {
+                k: set(v) if isinstance(v, set) else v for k, v in tmpl.items()
+            }
+            # Initialize opcode completion flags
+            self.npu_dma_in_opcode_done[name] = True
+            self.npu_cmd_opcode_done[name] = True
+            self.npu_dma_out_opcode_done[name] = True
 
     def _gate_by_npu_sync(self, event):
-        """Delay NPU events while a sync is active for its program."""
-        wait = self.npu_sync_wait.get(event.program)
-        if not wait:
-            return False
-
-        # If the sync has been released this cycle we still block events until
-        # the next cycle to guarantee deterministic ordering with *_DONE events.
-        if (
-            event.event_type.startswith("NPU_")
-            and event.event_type
-            not in ("NPU_SYNC", "NPU_DMA_IN_DONE", "NPU_CMD_DONE", "NPU_DMA_OUT_DONE")
-            and (wait["types"] or wait.get("release_cycle") == self.engine.current_cycle)
-        ):
-            retry_evt = Event(
-                src=self,
-                dst=self,
-                cycle=self.engine.current_cycle + 1,
-                data_size=0,
-                program=event.program,
-                event_type=event.event_type,
-                payload=event.payload,
-            )
-            self.send_event(retry_evt)
-            return True
-
-        # Remove the entry once the release cycle has fully passed
-        if not wait["types"] and wait.get("release_cycle", -1) < self.engine.current_cycle:
-            del self.npu_sync_wait[event.program]
-
-        return False
-
+        allowed = ("NPU_SYNC", "NPU_DMA_IN_DONE", "NPU_CMD_DONE", "NPU_DMA_OUT_DONE")
+        return self.gate_by_sync(event, allowed)
 
     def handle_event(self, event):
         if event.event_type == "RUN_PROGRAM":
             prog = self.program_store.get(event.program)
             state = self.program_state.get(event.program)
-            if not prog or not state or state["pc"] >= len(prog):
+            if not prog or not state:
+                return
+            if state["pc"] >= len(prog) and not state.get("waiting"):
+                if (
+                    self.npu_dma_in_opcode_done.get(event.program, True)
+                    and self.npu_cmd_opcode_done.get(event.program, True)
+                    and self.npu_dma_out_opcode_done.get(event.program, True)
+                ):
+                    print(f"[CP] NPU task {event.program} 완료")
+                    self.active_npu_programs.pop(event.program, None)
                 return
             if state.get("waiting"):
-                retry = Event(src=self, dst=self,
-                              cycle=self.engine.current_cycle + 1,
-                              program=event.program,
-                              event_type="RUN_PROGRAM")
+                retry = Event(
+                    src=self,
+                    dst=self,
+                    cycle=self.engine.current_cycle + 1,
+                    program=event.program,
+                    event_type="RUN_PROGRAM",
+                )
                 self.engine.push_event(retry)
                 return
             instr = prog[state["pc"]]
             state["pc"] += 1
             if instr["event_type"] == "NPU_SYNC":
                 state["waiting"] = True
-            instr_evt = Event(src=None, dst=self,
-                              cycle=self.engine.current_cycle,
-                              program=event.program,
-                              event_type=instr["event_type"],
-                              payload=instr.get("payload", {}))
+            elif instr["event_type"] == "NPU_DMA_IN":
+                self.npu_dma_in_opcode_done[event.program] = False
+            elif instr["event_type"] == "NPU_CMD":
+                self.npu_cmd_opcode_done[event.program] = False
+            elif instr["event_type"] == "NPU_DMA_OUT":
+                self.npu_dma_out_opcode_done[event.program] = False
+            instr_evt = Event(
+                src=None,
+                dst=self,
+                cycle=self.engine.current_cycle,
+                program=event.program,
+                event_type=instr["event_type"],
+                payload=instr.get("payload", {}),
+            )
             self.engine.push_event(instr_evt)
             if state["pc"] < len(prog) or state.get("waiting"):
-                nxt = Event(src=self, dst=self,
-                            cycle=self.engine.current_cycle + 1,
-                            program=event.program,
-                            event_type="RUN_PROGRAM")
+                nxt = Event(
+                    src=self,
+                    dst=self,
+                    cycle=self.engine.current_cycle + 1,
+                    program=event.program,
+                    event_type="RUN_PROGRAM",
+                )
                 self.engine.push_event(nxt)
+            else:
+                if (
+                    self.npu_dma_in_opcode_done.get(event.program, True)
+                    and self.npu_cmd_opcode_done.get(event.program, True)
+                    and self.npu_dma_out_opcode_done.get(event.program, True)
+                ):
+                    print(f"[CP] NPU task {event.program} 완료")
+                    self.active_npu_programs.pop(event.program, None)
             return
 
         if event.event_type == "GEMM":
-            print(f"[CP] GEMM 시작: {event.program}, shape={event.payload['gemm_shape']}")
+            print(
+                f"[CP] GEMM 시작: {event.program}, shape={event.payload['gemm_shape']}"
+            )
             state = {
                 "waiting_dma_in": set(pe.name for pe in self.pes),
                 "waiting_gemm": set(pe.name for pe in self.pes),
@@ -210,11 +255,11 @@ class ControlProcessor(HardwareModule):
             if self._gate_by_npu_sync(event):
                 return
 
-            prog_state = self._create_program_state(event.payload)
-            self.active_npu_programs[event.program] = prog_state
+            prog_state = self.active_npu_programs.get(event.program)
+            if not prog_state:
+                raise KeyError(f"Unknown NPU program {event.program}")
+            prog_state["waiting_dma_in"] = set(n.name for n in self.npus)
             self.npu_dma_in_opcode_done[event.program] = False
-            self.npu_cmd_opcode_done.setdefault(event.program, True)
-            self.npu_dma_out_opcode_done.setdefault(event.program, True)
             for npu in self.npus:
                 dma_evt = Event(
                     src=self,
@@ -241,7 +286,7 @@ class ControlProcessor(HardwareModule):
 
             program = self.active_npu_programs.get(event.program)
             if not program:
-                return
+                raise KeyError(f"Unknown NPU program {event.program}")
             program["waiting_op"] = set(n.name for n in self.npus)
             self.npu_cmd_opcode_done[event.program] = False
             for npu in self.npus:
@@ -269,7 +314,7 @@ class ControlProcessor(HardwareModule):
 
             program = self.active_npu_programs.get(event.program)
             if not program:
-                return
+                raise KeyError(f"Unknown NPU program {event.program}")
             program["waiting_dma_out"] = set(n.name for n in self.npus)
             self.npu_dma_out_opcode_done[event.program] = False
             for npu in self.npus:
@@ -292,76 +337,38 @@ class ControlProcessor(HardwareModule):
                 )
                 self.send_event(out_evt)
 
-
         elif event.event_type == "NPU_DMA_IN_DONE":
-            prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
-            npu_name = event.payload["npu_name"]
-            prog_state["waiting_dma_in"].discard(npu_name)
-            if not prog_state["waiting_dma_in"]:
-                # Mark completion so external modules can trigger the next phase
-                self.npu_dma_in_opcode_done[event.program] = True
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "dma_in" in wait["types"]:
-                    wait["types"].discard("dma_in")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            self.process_phase_done(
+                event.program,
+                event.payload["npu_name"],
+                self.active_npu_programs,
+                "waiting_dma_in",
+                self.npu_dma_in_opcode_done,
+                "dma_in",
+                lambda: self._resume_program(event.program),
+            )
 
         elif event.event_type == "NPU_CMD_DONE":
-            prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
-            npu_name = event.payload["npu_name"]
-            prog_state["waiting_op"].discard(npu_name)
-            if not prog_state["waiting_op"]:
-                # Command phase finished
-                self.npu_cmd_opcode_done[event.program] = True
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "cmd" in wait["types"]:
-                    wait["types"].discard("cmd")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            self.process_phase_done(
+                event.program,
+                event.payload["npu_name"],
+                self.active_npu_programs,
+                "waiting_op",
+                self.npu_cmd_opcode_done,
+                "cmd",
+                lambda: self._resume_program(event.program),
+            )
 
         elif event.event_type == "NPU_DMA_OUT_DONE":
-            prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                return
-            npu_name = event.payload["npu_name"]
-            prog_state["waiting_dma_out"].discard(npu_name)
-            if not prog_state["waiting_dma_out"]:
-                print(f"[CP] NPU task {event.program} 완료")
-                self.npu_dma_out_opcode_done[event.program] = True
-                self.active_npu_programs.pop(event.program, None)
-                wait = self.npu_sync_wait.get(event.program)
-                if wait and "dma_out" in wait["types"]:
-                    wait["types"].discard("dma_out")
-                    if not wait["types"]:
-                        wait["release_cycle"] = self.engine.current_cycle
-                        state = self.program_state.get(event.program)
-                        if state:
-                            state["waiting"] = False
-                            resume = Event(src=self, dst=self,
-                                           cycle=self.engine.current_cycle + 1,
-                                           program=event.program,
-                                           event_type="RUN_PROGRAM")
-                            self.engine.push_event(resume)
+            self.process_phase_done(
+                event.program,
+                event.payload["npu_name"],
+                self.active_npu_programs,
+                "waiting_dma_out",
+                self.npu_dma_out_opcode_done,
+                "dma_out",
+                lambda: self._resume_program(event.program),
+            )
 
         else:
             super().handle_event(event)

--- a/tests/test_npu_extended.py
+++ b/tests/test_npu_extended.py
@@ -1,0 +1,187 @@
+import unittest
+import sys, os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sim_core.engine import SimulatorEngine
+from sim_core.mesh import create_mesh
+from sim_core.event import Event
+from sim_hw.cp import ControlProcessor
+from sim_hw.npu import NPU
+from sim_hw.dram import DRAM
+
+
+def setup_env():
+    engine = SimulatorEngine()
+    mesh_info = {
+        "mesh_size": (3, 1),
+        "router_map": None,
+        "npu_coords": {},
+        "pe_coords": {},
+        "cp_coords": {},
+        "dram_coords": {},
+    }
+    mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
+    mesh_info["router_map"] = mesh
+    npu = NPU(engine, "NPU_0", mesh_info, buffer_capacity=1)
+    mesh_info["npu_coords"]["NPU_0"] = (0, 0)
+    mesh_info["pe_coords"]["NPU_0"] = (0, 0)
+    mesh[(0, 0)].attach_module(npu)
+    engine.register_module(npu)
+    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
+    mesh_info["dram_coords"]["DRAM"] = (1, 0)
+    mesh[(1, 0)].attach_module(dram)
+    engine.register_module(dram)
+    cp = ControlProcessor(
+        engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1
+    )
+    mesh_info["cp_coords"]["CP"] = (2, 0)
+    mesh[(2, 0)].attach_module(cp)
+    engine.register_module(cp)
+    return engine, cp
+
+
+class NPUExtendedTest(unittest.TestCase):
+    def test_multiple_dma_in(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+            {"event_type": "NPU_CMD", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["cmd"]}},
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+            {"event_type": "NPU_CMD", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["cmd"]}},
+        ]
+        cp.load_program("prog_multi", instrs)
+        cp.send_event(
+            Event(
+                src=None,
+                dst=cp,
+                cycle=1,
+                program="prog_multi",
+                event_type="RUN_PROGRAM",
+            )
+        )
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_multi"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("prog_multi"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_multi"))
+        self.assertEqual(len(engine.event_queue), 0)
+
+    def test_concurrent_dma_in_out(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_DMA_OUT", "payload": cfg},
+        ]
+        cp.load_program("prog_concurrent", instrs)
+        cp.send_event(
+            Event(
+                src=None,
+                dst=cp,
+                cycle=1,
+                program="prog_concurrent",
+                event_type="RUN_PROGRAM",
+            )
+        )
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_concurrent"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_concurrent"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("prog_concurrent"))
+        self.assertEqual(len(engine.event_queue), 0)
+        self.assertFalse(cp.active_npu_programs)
+
+    def test_random_dma_sequence(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+
+        import random
+
+        random.seed(0)
+        instrs = []
+        for _ in range(4):
+            if random.random() < 0.5:
+                instrs.append({"event_type": "NPU_DMA_OUT", "payload": cfg})
+                instrs.append(
+                    {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_out"]}}
+                )
+            else:
+                instrs.append({"event_type": "NPU_DMA_IN", "payload": cfg})
+                instrs.append(
+                    {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}}
+                )
+
+        cp.load_program("prog_random", instrs)
+        cp.send_event(
+            Event(
+                src=None,
+                dst=cp,
+                cycle=1,
+                program="prog_random",
+                event_type="RUN_PROGRAM",
+            )
+        )
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_random", True))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_random", True))
+        self.assertEqual(len(engine.event_queue), 0)
+        self.assertFalse(cp.active_npu_programs)
+
+    def test_end_with_sync(self):
+        engine, cp = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_DMA_OUT", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_out"]}},
+        ]
+        cp.load_program("prog_sync_end", instrs)
+        cp.send_event(
+            Event(
+                src=None,
+                dst=cp,
+                cycle=1,
+                program="prog_sync_end",
+                event_type="RUN_PROGRAM",
+            )
+        )
+        engine.run_until_idle(max_tick=500)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("prog_sync_end"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("prog_sync_end"))
+        self.assertEqual(len(engine.event_queue), 0)
+        self.assertFalse(cp.active_npu_programs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- set DMA/CMD opcode completion flags when registering programs
- rely on existing entries instead of defaulting inside handlers

## Testing
- `pip install torch torchvision torchaudio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678da8b0088330ba6aef7e30361ea5