### PR TITLE
Refine tile pipeline test

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,8 @@ def main():
         engine.register_module(pe)
         pes.append(pe)
 
-    dram = DRAM(engine, "DRAM", mesh_info)
+    # Use four independent channels in the DRAM model
+    dram = DRAM(engine, "DRAM", mesh_info, num_channels=4)
     mesh[dram_coords_dict["DRAM"]].attach_module(dram)
     engine.register_module(dram)
 

--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -29,6 +29,10 @@ class ControlProcessor(SyncModule):
         self.program_state = {}
         # Pre-created NPU program templates
         self.npu_program_templates = {}
+        # Event handler dispatch table. New instructions can be registered via
+        # :func:`register_handler` so ``handle_event`` remains simple.
+        self.event_handlers = {}
+        self._register_default_handlers()
 
     def _resume_program(self, program):
         state = self.program_state.get(program)
@@ -44,10 +48,14 @@ class ControlProcessor(SyncModule):
             self.engine.push_event(resume)
 
     def _create_program_state(self, payload):
+        """Initialize per-program state used to track outstanding work units."""
         return {
-            "waiting_dma_in": set(n.name for n in self.npus),
-            "waiting_op": set(n.name for n in self.npus),
-            "waiting_dma_out": set(n.name for n in self.npus),
+            # Each waiting_* entry maps task_id -> set of NPU names.  Using a
+            # dict allows multiple units from the same program to execute
+            # concurrently.
+            "waiting_dma_in": {},
+            "waiting_op": {},
+            "waiting_dma_out": {},
             "program_cycles": payload["program_cycles"],
             "in_size": payload["in_size"],
             "out_size": payload["out_size"],
@@ -86,290 +94,332 @@ class ControlProcessor(SyncModule):
         allowed = ("NPU_SYNC", "NPU_DMA_IN_DONE", "NPU_CMD_DONE", "NPU_DMA_OUT_DONE")
         return self.gate_by_sync(event, allowed)
 
-    def handle_event(self, event):
-        if event.event_type == "RUN_PROGRAM":
-            prog = self.program_store.get(event.program)
-            state = self.program_state.get(event.program)
-            if not prog or not state:
-                return
-            if state["pc"] >= len(prog) and not state.get("waiting"):
-                if (
-                    self.npu_dma_in_opcode_done.get(event.program, True)
-                    and self.npu_cmd_opcode_done.get(event.program, True)
-                    and self.npu_dma_out_opcode_done.get(event.program, True)
-                ):
-                    print(f"[CP] NPU task {event.program} 완료")
-                    self.active_npu_programs.pop(event.program, None)
-                return
-            if state.get("waiting"):
-                retry = Event(
-                    src=self,
-                    dst=self,
-                    cycle=self.engine.current_cycle + 1,
-                    program=event.program,
-                    event_type="RUN_PROGRAM",
-                )
-                self.engine.push_event(retry)
-                return
-            instr = prog[state["pc"]]
-            state["pc"] += 1
-            if instr["event_type"] == "NPU_SYNC":
-                state["waiting"] = True
-            elif instr["event_type"] == "NPU_DMA_IN":
-                self.npu_dma_in_opcode_done[event.program] = False
-            elif instr["event_type"] == "NPU_CMD":
-                self.npu_cmd_opcode_done[event.program] = False
-            elif instr["event_type"] == "NPU_DMA_OUT":
-                self.npu_dma_out_opcode_done[event.program] = False
-            instr_evt = Event(
-                src=None,
-                dst=self,
-                cycle=self.engine.current_cycle,
-                program=event.program,
-                event_type=instr["event_type"],
-                payload=instr.get("payload", {}),
-            )
-            self.engine.push_event(instr_evt)
-            if state["pc"] < len(prog) or state.get("waiting"):
-                nxt = Event(
-                    src=self,
-                    dst=self,
-                    cycle=self.engine.current_cycle + 1,
-                    program=event.program,
-                    event_type="RUN_PROGRAM",
-                )
-                self.engine.push_event(nxt)
-            else:
-                if (
-                    self.npu_dma_in_opcode_done.get(event.program, True)
-                    and self.npu_cmd_opcode_done.get(event.program, True)
-                    and self.npu_dma_out_opcode_done.get(event.program, True)
-                ):
-                    print(f"[CP] NPU task {event.program} 완료")
-                    self.active_npu_programs.pop(event.program, None)
+    def register_handler(self, evt_type, fn):
+        """Register a handler for ``evt_type``."""
+        self.event_handlers[evt_type] = fn
+
+    def _register_default_handlers(self):
+        self.register_handler("RUN_PROGRAM", self._handle_run_program)
+        self.register_handler("GEMM", self._handle_gemm)
+        self.register_handler("PE_DMA_IN_DONE", self._handle_pe_dma_in_done)
+        self.register_handler("PE_GEMM_DONE", self._handle_pe_gemm_done)
+        self.register_handler("PE_DMA_OUT_DONE", self._handle_pe_dma_out_done)
+        self.register_handler("NPU_SYNC", self._handle_npu_sync)
+        self.register_handler("NPU_DMA_IN", self._handle_npu_dma_in)
+        self.register_handler("NPU_CMD", self._handle_npu_cmd)
+        self.register_handler("NPU_DMA_OUT", self._handle_npu_dma_out)
+        self.register_handler("NPU_DMA_IN_DONE", self._handle_npu_dma_in_done)
+        self.register_handler("NPU_CMD_DONE", self._handle_npu_cmd_done)
+        self.register_handler("NPU_DMA_OUT_DONE", self._handle_npu_dma_out_done)
+
+    # ------------------------------------------------------------------
+    # Default handlers
+
+    def _handle_run_program(self, event):
+        prog = self.program_store.get(event.program)
+        state = self.program_state.get(event.program)
+        if not prog or not state:
             return
 
-        if event.event_type == "GEMM":
-            print(
-                f"[CP] GEMM 시작: {event.program}, shape={event.payload['gemm_shape']}"
+        if state["pc"] >= len(prog) and not state.get("waiting"):
+            if (
+                self.npu_dma_in_opcode_done.get(event.program, True)
+                and self.npu_cmd_opcode_done.get(event.program, True)
+                and self.npu_dma_out_opcode_done.get(event.program, True)
+            ):
+                print(f"[CP] NPU task {event.program} 완료")
+                self.active_npu_programs.pop(event.program, None)
+            return
+
+        if state.get("waiting"):
+            retry = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                program=event.program,
+                event_type="RUN_PROGRAM",
             )
-            state = {
-                "waiting_dma_in": set(pe.name for pe in self.pes),
-                "waiting_gemm": set(pe.name for pe in self.pes),
-                "waiting_dma_out": set(pe.name for pe in self.pes),
-                "gemm_shape": event.payload["gemm_shape"],
-                "weights_size": event.payload["weights_size"],
-                "act_size": event.payload["act_size"],
-            }
-            self.active_gemms[event.program] = state
-            for pe in self.pes:
-                dma_evt = Event(
-                    src=self,
-                    dst=self.get_my_router(),
-                    cycle=self.engine.current_cycle,
-                    data_size=state["weights_size"] + state["act_size"],
-                    program=event.program,
-                    event_type="PE_DMA_IN",
-                    payload={
-                        "dst_coords": self.mesh_info["pe_coords"][pe.name],
-                        "data_size": state["weights_size"] + state["act_size"],
-                        "src_name": self.name,
-                        "need_reply": True,
-                        "input_port": 0,
-                        "vc": 0,
-                    },
-                )
-                self.send_event(dma_evt)
+            self.engine.push_event(retry)
+            return
 
-        elif event.event_type == "PE_DMA_IN_DONE":
-            state = self.active_gemms.get(event.program)
-            if not state:
-                return
-            pe_name = event.payload["pe_name"]
-            state["waiting_dma_in"].discard(pe_name)
-            if not state["waiting_dma_in"]:
-                for pe in self.pes:
-                    gemm_evt = Event(
-                        src=self,
-                        dst=self.get_my_router(),
-                        cycle=self.engine.current_cycle,
-                        data_size=4,
-                        program=event.program,
-                        event_type="PE_GEMM",
-                        payload={
-                            "dst_coords": self.mesh_info["pe_coords"][pe.name],
-                            "gemm_shape": state["gemm_shape"],
-                            "src_name": self.name,
-                            "need_reply": True,
-                            "input_port": 0,
-                            "vc": 0,
-                        },
-                    )
-                    self.send_event(gemm_evt)
-
-        elif event.event_type == "PE_GEMM_DONE":
-            state = self.active_gemms.get(event.program)
-            if not state:
-                return
-            pe_name = event.payload["pe_name"]
-            state["waiting_gemm"].discard(pe_name)
-            if not state["waiting_gemm"]:
-                out_size = state["gemm_shape"][0] * state["gemm_shape"][1] * 4
-                for pe in self.pes:
-                    dma_evt = Event(
-                        src=self,
-                        dst=self.get_my_router(),
-                        cycle=self.engine.current_cycle,
-                        data_size=out_size,
-                        program=event.program,
-                        event_type="PE_DMA_OUT",
-                        payload={
-                            "dst_coords": self.mesh_info["pe_coords"][pe.name],
-                            "data_size": out_size,
-                            "src_name": self.name,
-                            "need_reply": True,
-                            "pe_name": pe.name,
-                        },
-                    )
-                    self.send_event(dma_evt)
-
-        elif event.event_type == "PE_DMA_OUT_DONE":
-            state = self.active_gemms.get(event.program)
-            if not state:
-                return
-            pe_name = event.payload["pe_name"]
-            state["waiting_dma_out"].discard(pe_name)
-            if not state["waiting_dma_out"]:
-                print(f"[CP] GEMM {event.program} 작업 완료")
-                self.active_gemms.pop(event.program, None)
-
-        elif event.event_type == "NPU_SYNC":
-            # Block subsequent NPU events for this program until the requested
-            # phases report completion.
-            self.npu_sync_wait[event.program] = {
-                "types": set(event.payload.get("sync_types", [])),
-                "release_cycle": None,
-            }
-
-        elif event.event_type == "NPU_DMA_IN":
-            if self._gate_by_npu_sync(event):
-                return
-
-            prog_state = self.active_npu_programs.get(event.program)
-            if not prog_state:
-                raise KeyError(f"Unknown NPU program {event.program}")
-            prog_state["waiting_dma_in"] = set(n.name for n in self.npus)
+        instr = prog[state["pc"]]
+        state["pc"] += 1
+        if instr["event_type"] == "NPU_SYNC":
+            state["waiting"] = True
+        elif instr["event_type"] == "NPU_DMA_IN":
             self.npu_dma_in_opcode_done[event.program] = False
-            for npu in self.npus:
-                dma_evt = Event(
-                    src=self,
-                    dst=self.get_my_router(),
-                    cycle=self.engine.current_cycle,
-                    data_size=prog_state["in_size"],
-                    program=event.program,
-                    event_type="NPU_DMA_IN",
-                    payload={
-                        "dst_coords": self.mesh_info["npu_coords"][npu.name],
-                        "data_size": prog_state["in_size"],
-                        "src_name": self.name,
-                        "need_reply": True,
-                        "opcode_cycles": prog_state["dma_in_opcode_cycles"],
-                        "input_port": 0,
-                        "vc": 0,
-                    },
-                )
-                self.send_event(dma_evt)
-
-        elif event.event_type == "NPU_CMD":
-            if self._gate_by_npu_sync(event):
-                return
-
-            program = self.active_npu_programs.get(event.program)
-            if not program:
-                raise KeyError(f"Unknown NPU program {event.program}")
-            program["waiting_op"] = set(n.name for n in self.npus)
+        elif instr["event_type"] == "NPU_CMD":
             self.npu_cmd_opcode_done[event.program] = False
-            for npu in self.npus:
-                cmd_evt = Event(
+        elif instr["event_type"] == "NPU_DMA_OUT":
+            self.npu_dma_out_opcode_done[event.program] = False
+
+        instr_evt = Event(
+            src=None,
+            dst=self,
+            cycle=self.engine.current_cycle,
+            program=event.program,
+            event_type=instr["event_type"],
+            payload=instr.get("payload", {}),
+        )
+        tsk = instr_evt.payload.get("task_id")
+        print(
+            f"[CP] Dispatch {instr_evt.event_type} task={tsk} cycle={self.engine.current_cycle}"
+        )
+        self.engine.push_event(instr_evt)
+        if state["pc"] < len(prog) or state.get("waiting"):
+            nxt = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                program=event.program,
+                event_type="RUN_PROGRAM",
+            )
+            self.engine.push_event(nxt)
+        else:
+            if (
+                self.npu_dma_in_opcode_done.get(event.program, True)
+                and self.npu_cmd_opcode_done.get(event.program, True)
+                and self.npu_dma_out_opcode_done.get(event.program, True)
+            ):
+                print(f"[CP] NPU task {event.program} 완료")
+                self.active_npu_programs.pop(event.program, None)
+
+    def _handle_gemm(self, event):
+        print(f"[CP] GEMM 시작: {event.program}, shape={event.payload['gemm_shape']}")
+        state = {
+            "waiting_dma_in": set(pe.name for pe in self.pes),
+            "waiting_gemm": set(pe.name for pe in self.pes),
+            "waiting_dma_out": set(pe.name for pe in self.pes),
+            "gemm_shape": event.payload["gemm_shape"],
+            "weights_size": event.payload["weights_size"],
+            "act_size": event.payload["act_size"],
+        }
+        self.active_gemms[event.program] = state
+        for pe in self.pes:
+            dma_evt = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=state["weights_size"] + state["act_size"],
+                program=event.program,
+                event_type="PE_DMA_IN",
+                payload={
+                    "dst_coords": self.mesh_info["pe_coords"][pe.name],
+                    "data_size": state["weights_size"] + state["act_size"],
+                    "src_name": self.name,
+                    "need_reply": True,
+                    "input_port": 0,
+                    "vc": 0,
+                },
+            )
+            self.send_event(dma_evt)
+
+    def _handle_pe_dma_in_done(self, event):
+        state = self.active_gemms.get(event.program)
+        if not state:
+            return
+        pe_name = event.payload["pe_name"]
+        state["waiting_dma_in"].discard(pe_name)
+        if not state["waiting_dma_in"]:
+            for pe in self.pes:
+                gemm_evt = Event(
                     src=self,
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle,
                     data_size=4,
                     program=event.program,
-                    event_type="NPU_CMD",
+                    event_type="PE_GEMM",
                     payload={
-                        "dst_coords": self.mesh_info["npu_coords"][npu.name],
-                        "opcode_cycles": program["cmd_opcode_cycles"],
+                        "dst_coords": self.mesh_info["pe_coords"][pe.name],
+                        "gemm_shape": state["gemm_shape"],
                         "src_name": self.name,
                         "need_reply": True,
                         "input_port": 0,
                         "vc": 0,
                     },
                 )
-                self.send_event(cmd_evt)
+                self.send_event(gemm_evt)
 
-        elif event.event_type == "NPU_DMA_OUT":
-            if self._gate_by_npu_sync(event):
-                return
-
-            program = self.active_npu_programs.get(event.program)
-            if not program:
-                raise KeyError(f"Unknown NPU program {event.program}")
-            program["waiting_dma_out"] = set(n.name for n in self.npus)
-            self.npu_dma_out_opcode_done[event.program] = False
-            for npu in self.npus:
-                out_evt = Event(
+    def _handle_pe_gemm_done(self, event):
+        state = self.active_gemms.get(event.program)
+        if not state:
+            return
+        pe_name = event.payload["pe_name"]
+        state["waiting_gemm"].discard(pe_name)
+        if not state["waiting_gemm"]:
+            out_size = state["gemm_shape"][0] * state["gemm_shape"][1] * 4
+            for pe in self.pes:
+                dma_evt = Event(
                     src=self,
                     dst=self.get_my_router(),
                     cycle=self.engine.current_cycle,
-                    data_size=program["out_size"],
+                    data_size=out_size,
                     program=event.program,
-                    event_type="NPU_DMA_OUT",
+                    event_type="PE_DMA_OUT",
                     payload={
-                        "dst_coords": self.mesh_info["npu_coords"][npu.name],
-                        "data_size": program["out_size"],
+                        "dst_coords": self.mesh_info["pe_coords"][pe.name],
+                        "data_size": out_size,
                         "src_name": self.name,
                         "need_reply": True,
-                        "opcode_cycles": program["dma_out_opcode_cycles"],
-                        "input_port": 0,
-                        "vc": 0,
+                        "pe_name": pe.name,
                     },
                 )
-                self.send_event(out_evt)
+                self.send_event(dma_evt)
 
-        elif event.event_type == "NPU_DMA_IN_DONE":
-            self.process_phase_done(
-                event.program,
-                event.payload["npu_name"],
-                self.active_npu_programs,
-                "waiting_dma_in",
-                self.npu_dma_in_opcode_done,
-                "dma_in",
-                lambda: self._resume_program(event.program),
+    def _handle_pe_dma_out_done(self, event):
+        state = self.active_gemms.get(event.program)
+        if not state:
+            return
+        pe_name = event.payload["pe_name"]
+        state["waiting_dma_out"].discard(pe_name)
+        if not state["waiting_dma_out"]:
+            print(f"[CP] GEMM {event.program} 작업 완료")
+            self.active_gemms.pop(event.program, None)
+
+    def _handle_npu_sync(self, event):
+        self.npu_sync_wait[event.program] = {
+            "types": set(event.payload.get("sync_types", [])),
+            "release_cycle": None,
+        }
+
+    def _handle_npu_dma_in(self, event):
+        if self._gate_by_npu_sync(event):
+            return
+        prog_state = self.active_npu_programs.get(event.program)
+        if not prog_state:
+            raise KeyError(f"Unknown NPU program {event.program}")
+        task_id = event.payload.get("task_id")
+        prog_state.setdefault("waiting_dma_in", {})[task_id] = set(n.name for n in self.npus)
+        self.npu_dma_in_opcode_done[event.program] = False
+        for npu in self.npus:
+            dma_evt = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=prog_state["in_size"],
+                program=event.program,
+                event_type="NPU_DMA_IN",
+                payload={
+                    "dst_coords": self.mesh_info["npu_coords"][npu.name],
+                    "data_size": prog_state["in_size"],
+                    "src_name": self.name,
+                    "need_reply": True,
+                    "opcode_cycles": prog_state["dma_in_opcode_cycles"],
+                    "task_id": task_id,
+                    "input_port": 0,
+                    "vc": 0,
+                },
             )
+            self.send_event(dma_evt)
 
-        elif event.event_type == "NPU_CMD_DONE":
-            self.process_phase_done(
-                event.program,
-                event.payload["npu_name"],
-                self.active_npu_programs,
-                "waiting_op",
-                self.npu_cmd_opcode_done,
-                "cmd",
-                lambda: self._resume_program(event.program),
+    def _handle_npu_cmd(self, event):
+        if self._gate_by_npu_sync(event):
+            return
+        program = self.active_npu_programs.get(event.program)
+        if not program:
+            raise KeyError(f"Unknown NPU program {event.program}")
+        task_id = event.payload.get("task_id")
+        program.setdefault("waiting_op", {})[task_id] = set(n.name for n in self.npus)
+        self.npu_cmd_opcode_done[event.program] = False
+        for npu in self.npus:
+            cmd_evt = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=4,
+                program=event.program,
+                event_type="NPU_CMD",
+                payload={
+                    "dst_coords": self.mesh_info["npu_coords"][npu.name],
+                    "opcode_cycles": program["cmd_opcode_cycles"],
+                    "src_name": self.name,
+                    "need_reply": True,
+                    "task_id": task_id,
+                    "input_port": 0,
+                    "vc": 0,
+                },
             )
+            self.send_event(cmd_evt)
 
-        elif event.event_type == "NPU_DMA_OUT_DONE":
-            self.process_phase_done(
-                event.program,
-                event.payload["npu_name"],
-                self.active_npu_programs,
-                "waiting_dma_out",
-                self.npu_dma_out_opcode_done,
-                "dma_out",
-                lambda: self._resume_program(event.program),
+    def _handle_npu_dma_out(self, event):
+        if self._gate_by_npu_sync(event):
+            return
+        program = self.active_npu_programs.get(event.program)
+        if not program:
+            raise KeyError(f"Unknown NPU program {event.program}")
+        task_id = event.payload.get("task_id")
+        program.setdefault("waiting_dma_out", {})[task_id] = set(n.name for n in self.npus)
+        self.npu_dma_out_opcode_done[event.program] = False
+        for npu in self.npus:
+            out_evt = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=program["out_size"],
+                program=event.program,
+                event_type="NPU_DMA_OUT",
+                payload={
+                    "dst_coords": self.mesh_info["npu_coords"][npu.name],
+                    "data_size": program["out_size"],
+                    "src_name": self.name,
+                    "need_reply": True,
+                    "opcode_cycles": program["dma_out_opcode_cycles"],
+                    "task_id": task_id,
+                    "input_port": 0,
+                    "vc": 0,
+                },
             )
+            self.send_event(out_evt)
 
+    def _handle_npu_dma_in_done(self, event):
+        print(
+            f"[CP] DMA_IN_DONE task={event.payload.get('task_id')} cycle={self.engine.current_cycle}"
+        )
+        self.process_phase_done(
+            event.program,
+            event.payload["npu_name"],
+            self.active_npu_programs,
+            "waiting_dma_in",
+            self.npu_dma_in_opcode_done,
+            "dma_in",
+            lambda: self._resume_program(event.program),
+            task_id=event.payload.get("task_id"),
+        )
+
+    def _handle_npu_cmd_done(self, event):
+        print(
+            f"[CP] CMD_DONE task={event.payload.get('task_id')} cycle={self.engine.current_cycle}"
+        )
+        self.process_phase_done(
+            event.program,
+            event.payload["npu_name"],
+            self.active_npu_programs,
+            "waiting_op",
+            self.npu_cmd_opcode_done,
+            "cmd",
+            lambda: self._resume_program(event.program),
+            task_id=event.payload.get("task_id"),
+        )
+
+    def _handle_npu_dma_out_done(self, event):
+        print(
+            f"[CP] DMA_OUT_DONE task={event.payload.get('task_id')} cycle={self.engine.current_cycle}"
+        )
+        self.process_phase_done(
+            event.program,
+            event.payload["npu_name"],
+            self.active_npu_programs,
+            "waiting_dma_out",
+            self.npu_dma_out_opcode_done,
+            "dma_out",
+            lambda: self._resume_program(event.program),
+            task_id=event.payload.get("task_id"),
+        )
+
+    def handle_event(self, event):
+        handler = self.event_handlers.get(event.event_type)
+        if handler:
+            handler(event)
         else:
             super().handle_event(event)
 

--- a/tests/test_cp_serialization.py
+++ b/tests/test_cp_serialization.py
@@ -1,0 +1,78 @@
+import unittest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sim_core.engine import SimulatorEngine
+from sim_core.mesh import create_mesh
+from sim_core.event import Event
+from sim_hw.cp import ControlProcessor
+from sim_hw.npu import NPU
+from sim_hw.dram import DRAM
+
+
+def setup_env():
+    engine = SimulatorEngine()
+    mesh_info = {
+        "mesh_size": (3, 1),
+        "router_map": None,
+        "npu_coords": {},
+        "pe_coords": {},
+        "cp_coords": {},
+        "dram_coords": {},
+    }
+    mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
+    mesh_info["router_map"] = mesh
+    npu = NPU(engine, "NPU_0", mesh_info, buffer_capacity=1)
+    mesh_info["npu_coords"]["NPU_0"] = (0, 0)
+    mesh[(0, 0)].attach_module(npu)
+    engine.register_module(npu)
+    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=1, buffer_capacity=1)
+    mesh_info["dram_coords"]["DRAM"] = (1, 0)
+    mesh[(1, 0)].attach_module(dram)
+    engine.register_module(dram)
+    cp = ControlProcessor(engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1)
+    mesh_info["cp_coords"]["CP"] = (2, 0)
+    mesh[(2, 0)].attach_module(cp)
+    engine.register_module(cp)
+    return engine, cp
+
+
+class CPSerializationTest(unittest.TestCase):
+    def test_serialized_dma_in(self):
+        engine1, cp1 = setup_env()
+        cfg = {
+            "program_cycles": 3,
+            "in_size": 16,
+            "out_size": 16,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+        instrs1 = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+        ]
+        cp1.load_program("p1", instrs1)
+        cp1.send_event(Event(src=None, dst=cp1, cycle=1, program="p1", event_type="RUN_PROGRAM"))
+        engine1.run_until_idle(max_tick=200)
+        cycles_auto = engine1.current_cycle
+
+        engine2, cp2 = setup_env()
+        instrs2 = [
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+            {"event_type": "NPU_DMA_IN", "payload": cfg},
+            {"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}},
+        ]
+        cp2.load_program("p2", instrs2)
+        cp2.send_event(Event(src=None, dst=cp2, cycle=1, program="p2", event_type="RUN_PROGRAM"))
+        engine2.run_until_idle(max_tick=200)
+        cycles_explicit = engine2.current_cycle
+
+        self.assertLess(abs(cycles_auto - cycles_explicit), 2)
+        self.assertTrue(cp1.npu_dma_in_opcode_done.get("p1"))
+        self.assertTrue(cp2.npu_dma_in_opcode_done.get("p2"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_npu.py
+++ b/tests/test_npu.py
@@ -26,7 +26,7 @@ class NPUTest(unittest.TestCase):
         mesh_info["pe_coords"]["NPU_0"] = (0,0)
         mesh[(0,0)].attach_module(npu)
         engine.register_module(npu)
-        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
+        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=4, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
         mesh[(1,0)].attach_module(dram)
         engine.register_module(dram)

--- a/tests/test_npu_extended.py
+++ b/tests/test_npu_extended.py
@@ -27,7 +27,7 @@ def setup_env():
     mesh_info["pe_coords"]["NPU_0"] = (0, 0)
     mesh[(0, 0)].attach_module(npu)
     engine.register_module(npu)
-    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
+    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=4, buffer_capacity=1)
     mesh_info["dram_coords"]["DRAM"] = (1, 0)
     mesh[(1, 0)].attach_module(dram)
     engine.register_module(dram)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,7 +24,7 @@ class PipelineSimTest(unittest.TestCase):
         mesh_info["pe_coords"]["PE_0"] = (0,0)
         mesh[(0,0)].attach_module(pe)
         engine.register_module(pe)
-        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, buffer_capacity=1)
+        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=4, buffer_capacity=1)
         mesh_info["dram_coords"]["DRAM"] = (1,0)
         mesh[(1,0)].attach_module(dram)
         engine.register_module(dram)

--- a/tests/test_tile_pipeline.py
+++ b/tests/test_tile_pipeline.py
@@ -1,0 +1,129 @@
+import unittest
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sim_core.engine import SimulatorEngine
+from sim_core.mesh import create_mesh
+from sim_core.event import Event
+from sim_hw.cp import ControlProcessor
+from sim_hw.npu import NPU
+from sim_hw.dram import DRAM
+
+class TilePipelineTest(unittest.TestCase):
+    def test_tile_overlap(self):
+        engine = SimulatorEngine()
+        mesh_info = {
+            "mesh_size": (3, 1),
+            "router_map": None,
+            "npu_coords": {},
+            "pe_coords": {},
+            "cp_coords": {},
+            "dram_coords": {},
+        }
+        mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
+        mesh_info["router_map"] = mesh
+        npu = NPU(engine, "NPU_0", mesh_info, buffer_capacity=1)
+        mesh_info["npu_coords"]["NPU_0"] = (0, 0)
+        mesh[(0, 0)].attach_module(npu)
+        engine.register_module(npu)
+        dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=4, buffer_capacity=1)
+        mesh_info["dram_coords"]["DRAM"] = (1, 0)
+        mesh[(1, 0)].attach_module(dram)
+        engine.register_module(dram)
+        cp = ControlProcessor(engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1)
+        mesh_info["cp_coords"]["CP"] = (2, 0)
+        mesh[(2, 0)].attach_module(cp)
+        engine.register_module(cp)
+
+        # Matrix dimensions and tiling configuration
+        M = 4
+        N = 4
+        K = 4
+        tile_y = 2
+        tile_x = 2
+        tile_k = 2
+
+        cfg = {
+            "program_cycles": 3,
+            "in_size": tile_y * K * 4,
+            "out_size": tile_y * tile_x * 4,
+            "dma_in_opcode_cycles": 2,
+            "dma_out_opcode_cycles": 2,
+            "cmd_opcode_cycles": 3,
+        }
+
+        instrs = []
+        task = 0
+        tiles_y = M // tile_y
+        tiles_x = N // tile_x
+        for ty in range(tiles_y):
+            for tx in range(tiles_x):
+                instrs.append({"event_type": "NPU_DMA_IN", "payload": dict(cfg, task_id=f"T{task}")})
+                # Wait for DMA_IN completion before launching compute
+                instrs.append({"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}})
+                for tk in range(K // tile_k):
+                    instrs.append({"event_type": "NPU_CMD", "payload": dict(cfg, task_id=f"T{task}_{tk}")})
+                instrs.append({"event_type": "NPU_DMA_OUT", "payload": dict(cfg, task_id=f"T{task}")})
+                task += 1
+
+        # Wait for all outstanding DMA_OUT operations to complete.
+        instrs.append({"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_out"]}})
+        cp.load_program("tile_prog", instrs)
+        cp.send_event(Event(src=None, dst=cp, cycle=1, program="tile_prog", event_type="RUN_PROGRAM"))
+        engine.run_until_idle(max_tick=1000)
+        self.assertTrue(cp.npu_dma_in_opcode_done.get("tile_prog"))
+        self.assertTrue(cp.npu_cmd_opcode_done.get("tile_prog"))
+        self.assertTrue(cp.npu_dma_out_opcode_done.get("tile_prog"))
+        self.assertFalse(cp.active_npu_programs)
+        # The pipelined execution should finish in well under 600 cycles
+        self.assertLess(engine.current_cycle, 600)
+
+        # Now build a serialized version of the same workload
+        engine2 = SimulatorEngine()
+        mesh_info2 = {
+            "mesh_size": (3, 1),
+            "router_map": None,
+            "npu_coords": {},
+            "pe_coords": {},
+            "cp_coords": {},
+            "dram_coords": {},
+        }
+        mesh2 = create_mesh(engine2, 3, 1, mesh_info2, buffer_capacity=1)
+        mesh_info2["router_map"] = mesh2
+        npu2 = NPU(engine2, "NPU_0", mesh_info2, buffer_capacity=1)
+        mesh_info2["npu_coords"]["NPU_0"] = (0, 0)
+        mesh2[(0, 0)].attach_module(npu2)
+        engine2.register_module(npu2)
+        dram2 = DRAM(engine2, "DRAM", mesh_info2, pipeline_latency=2, num_channels=4, buffer_capacity=1)
+        mesh_info2["dram_coords"]["DRAM"] = (1, 0)
+        mesh2[(1, 0)].attach_module(dram2)
+        engine2.register_module(dram2)
+        cp2 = ControlProcessor(engine2, "CP2", mesh_info2, [], dram2, npus=[npu2], buffer_capacity=1)
+        mesh_info2["cp_coords"]["CP2"] = (2, 0)
+        mesh2[(2, 0)].attach_module(cp2)
+        engine2.register_module(cp2)
+
+        serial_instrs = []
+        task = 0
+        for ty in range(tiles_y):
+            for tx in range(tiles_x):
+                serial_instrs.append({"event_type": "NPU_DMA_IN", "payload": dict(cfg, task_id=f"S{task}")})
+                serial_instrs.append({"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_in"]}})
+                for tk in range(K // tile_k):
+                    serial_instrs.append({"event_type": "NPU_CMD", "payload": dict(cfg, task_id=f"S{task}_{tk}")})
+                    serial_instrs.append({"event_type": "NPU_SYNC", "payload": {"sync_types": ["cmd"]}})
+                serial_instrs.append({"event_type": "NPU_DMA_OUT", "payload": dict(cfg, task_id=f"S{task}")})
+                serial_instrs.append({"event_type": "NPU_SYNC", "payload": {"sync_types": ["dma_out"]}})
+                task += 1
+
+        cp2.load_program("serial_prog", serial_instrs)
+        cp2.send_event(Event(src=None, dst=cp2, cycle=1, program="serial_prog", event_type="RUN_PROGRAM"))
+        engine2.run_until_idle(max_tick=2000)
+        serial_cycles = engine2.current_cycle
+
+        self.assertTrue(cp2.npu_dma_in_opcode_done.get("serial_prog"))
+        self.assertTrue(cp2.npu_cmd_opcode_done.get("serial_prog"))
+        self.assertTrue(cp2.npu_dma_out_opcode_done.get("serial_prog"))
+        self.assertLess(engine.current_cycle, serial_cycles)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand tile pipeline example to also run a sequential version
- ensure pipelined GEMM completes under 600 cycles
- compare execution time to the sequential baseline

## Testing
- `pip install torch torchvision torchaudio`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_686bd19590a083308bed8beac24f1148