### PR TITLE
Improve DRAM logging

### DIFF
--- a/sim_core/module.py
+++ b/sim_core/module.py
@@ -31,8 +31,11 @@ class HardwareModule:
                     if isinstance(event.payload, dict)
                     else 0
                 )
+                evt_type = event.event_type
+                if isinstance(event.payload, dict) and event.payload.get("op_type"):
+                    evt_type = f"{evt_type}-{event.payload['op_type']}"
                 self.engine.logger.log_event(
-                    self.engine.current_cycle, self.name, stage, event.event_type
+                    self.engine.current_cycle, self.name, stage, evt_type
                 )
             self.handle_event(event)
         finally:

--- a/sim_hw/dram.py
+++ b/sim_hw/dram.py
@@ -38,12 +38,15 @@ class DRAM(PipelineModule):
 
     def _schedule_channel(self, ch):
         if not self.channel_scheduled[ch]:
+            payload = {"channel_id": ch}
+            if self.channel_queues[ch]:
+                payload["op_type"] = self.channel_queues[ch][0]["type"]
             evt = Event(
                 src=self,
                 dst=self,
                 cycle=self.engine.current_cycle + 1,
                 event_type="DRAM_CHANNEL",
-                payload={"channel_id": ch},
+                payload=payload,
             )
             self.send_event(evt)
             self.channel_scheduled[ch] = True


### PR DESCRIPTION
## Summary
- include operation type in DRAM channel events
- log operation type in HardwareModule logger
- keep all tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c77f99aa883309fb33ac8aae74ad5