### PR TITLE
Implement IOD memory interface

### DIFF
--- a/sim_hw/cp.py
+++ b/sim_hw/cp.py
@@ -4,12 +4,14 @@ from sim_core.event import Event
 
 class ControlProcessor(HardwareModule):
     def __init__(
-        self, engine, name, mesh_info, pes, dram, npus=None, buffer_capacity=4
+        self, engine, name, mesh_info, pes, iod, npus=None, buffer_capacity=4
     ):
         super().__init__(engine, name, mesh_info, buffer_capacity)
         self.pes = pes
         self.npus = npus or []
-        self.dram = dram
+        # ``iod`` represents the memory interface used by NPUs. DRAM remains
+        # intact for PE operations.
+        self.iod = iod
         self.active_gemms = {}
         self.active_npu_programs = {}
         # Track synchronization state of NPU commands so external modules can
@@ -374,6 +376,8 @@ class ControlProcessor(HardwareModule):
                     "need_reply": True,
                     "opcode_cycles": prog_state["dma_in_opcode_cycles"],
                     "stream_id": sid,
+                    "eaddr": event.payload.get("eaddr"),
+                    "iaddr": event.payload.get("iaddr"),
                     "input_port": 0,
                     "vc": 0,
                 },
@@ -429,6 +433,8 @@ class ControlProcessor(HardwareModule):
                     "need_reply": True,
                     "opcode_cycles": program["dma_out_opcode_cycles"],
                     "stream_id": sid,
+                    "eaddr": event.payload.get("eaddr"),
+                    "iaddr": event.payload.get("iaddr"),
                     "input_port": 0,
                     "vc": 0,
                 },

--- a/sim_hw/iod.py
+++ b/sim_hw/iod.py
@@ -1,0 +1,182 @@
+from sim_core.module import PipelineModule
+from sim_core.event import Event
+
+class Bank:
+    def __init__(self):
+        self.active_row = None
+
+    def access(self, row):
+        delay = 0
+        if self.active_row != row:
+            if self.active_row is not None:
+                delay += 1  # precharge penalty
+            self.active_row = row
+            delay += 2  # activate penalty
+        delay += 1  # column access
+        return delay
+
+class BankGroup:
+    def __init__(self):
+        self.banks = [Bank() for _ in range(4)]
+
+    def access(self, bank, row):
+        return self.banks[bank].access(row)
+
+class HBMChannel:
+    def __init__(self):
+        self.bank_groups = [BankGroup() for _ in range(4)]
+
+    def access(self, bg, bank, row):
+        return self.bank_groups[bg].access(bank, row)
+
+class HBMStack:
+    def __init__(self, channels):
+        self.channels = [HBMChannel() for _ in range(channels)]
+
+    def access(self, ch, bg, bank, row):
+        return self.channels[ch].access(bg, bank, row)
+
+
+def decode_eaddr(addr):
+    return {
+        "stack": (addr >> 35) & 0x1,
+        "channel": (addr >> 31) & 0xF,
+        "bank_group": (addr >> 29) & 0x3,
+        "bank": (addr >> 27) & 0x3,
+        "row": (addr >> 11) & 0xFFFF,
+        "column": (addr >> 3) & 0xFF,
+        "byte_offset": addr & 0x7,
+    }
+
+class IOD(PipelineModule):
+    """Simplified IOD model with HBM stacks and memory controllers."""
+
+    def __init__(
+        self,
+        engine,
+        name,
+        mesh_info,
+        num_stacks=2,
+        channels_per_stack=16,
+        pipeline_latency=5,
+        buffer_capacity=4,
+    ):
+        super().__init__(engine, name, mesh_info, 1, buffer_capacity)
+        self.pipeline_latency = pipeline_latency
+        self.num_stacks = num_stacks
+        self.channels_per_stack = channels_per_stack
+        self.stacks = [HBMStack(channels_per_stack) for _ in range(num_stacks)]
+        self.mc_queues = [
+            [[ ] for _ in range(channels_per_stack)] for _ in range(num_stacks)
+        ]
+        self.mc_sched = [
+            [False for _ in range(channels_per_stack)] for _ in range(num_stacks)
+        ]
+        self.set_stage_funcs([self._stage_func])
+        self.event_handlers = {}
+        self._register_default_handlers()
+
+    def _stage_func(self, mod, data):
+        data["remaining"] -= 1
+        if data["remaining"] > 0:
+            return data, 0, True
+        return data, 1, False
+
+    def _schedule_mc(self, st, ch):
+        if not self.mc_sched[st][ch]:
+            payload = {"stack": st, "channel": ch}
+            if self.mc_queues[st][ch]:
+                payload["op_type"] = self.mc_queues[st][ch][0]["type"]
+            evt = Event(
+                src=self,
+                dst=self,
+                cycle=self.engine.current_cycle + 1,
+                event_type="IOD_MC",
+                payload=payload,
+            )
+            self.send_event(evt)
+            self.mc_sched[st][ch] = True
+
+    def register_handler(self, evt_type, fn):
+        self.event_handlers[evt_type] = fn
+
+    def _register_default_handlers(self):
+        self.register_handler("DMA_WRITE", self._handle_dma_access)
+        self.register_handler("DMA_READ", self._handle_dma_access)
+        self.register_handler("IOD_MC", self._handle_mc)
+
+    def handle_event(self, event):
+        handler = self.event_handlers.get(event.event_type)
+        if handler:
+            handler(event)
+        else:
+            super().handle_event(event)
+
+    def _handle_dma_access(self, event):
+        addr = event.payload.get("eaddr", 0)
+        info = decode_eaddr(addr)
+        st = info["stack"] % self.num_stacks
+        ch = info["channel"] % self.channels_per_stack
+        delay = self.stacks[st].access(ch, info["bank_group"], info["bank"], info["row"])
+        op = {
+            "type": event.event_type,
+            "program": event.program,
+            "src_name": event.payload["src_name"],
+            "stream_id": event.payload.get("stream_id"),
+            "remaining": self.pipeline_latency + delay,
+            "dst_name": event.payload.get("src_name") if event.payload.get("need_reply") else None,
+            "stack": st,
+            "channel": ch,
+        }
+        self.mc_queues[st][ch].append(op)
+        self._schedule_mc(st, ch)
+
+    def _handle_mc(self, event):
+        st = event.payload["stack"]
+        ch = event.payload["channel"]
+        self.mc_sched[st][ch] = False
+        if not self.mc_queues[st][ch]:
+            return
+        op = self.mc_queues[st][ch][0]
+        op["remaining"] -= 1
+        if op["remaining"] > 0:
+            self._schedule_mc(st, ch)
+            return
+        self.mc_queues[st][ch].pop(0)
+        self.handle_pipeline_output(op)
+        if self.mc_queues[st][ch]:
+            self._schedule_mc(st, ch)
+
+    def handle_pipeline_output(self, op):
+        if op["type"] == "DMA_WRITE":
+            evt_type = "WRITE_REPLY"
+        else:
+            evt_type = "DMA_READ_REPLY"
+        if op.get("dst_name"):
+            dst_name = op["dst_name"]
+            coords = (
+                self.mesh_info.get("pe_coords", {}).get(dst_name)
+                or self.mesh_info.get("npu_coords", {}).get(dst_name)
+                or self.mesh_info.get("cp_coords", {}).get(dst_name)
+            )
+            reply_event = Event(
+                src=self,
+                dst=self.get_my_router(),
+                cycle=self.engine.current_cycle,
+                data_size=4,
+                program=op["program"],
+                event_type=evt_type,
+                payload={
+                    "dst_coords": coords,
+                    "input_port": 0,
+                    "vc": 0,
+                    "stream_id": op.get("stream_id"),
+                    "stack": op.get("stack"),
+                    "channel": op.get("channel"),
+                },
+            )
+            self.send_event(reply_event)
+
+    def get_my_router(self):
+        coords = self.mesh_info["iod_coords"][self.name]
+        return self.mesh_info["router_map"][coords]

--- a/tests/test_cp_serialization.py
+++ b/tests/test_cp_serialization.py
@@ -6,7 +6,7 @@ from sim_core.mesh import create_mesh
 from sim_core.event import Event
 from sim_hw.cp import ControlProcessor
 from sim_hw.npu import NPU
-from sim_hw.dram import DRAM
+from sim_hw.iod import IOD
 
 
 def setup_env():
@@ -17,7 +17,7 @@ def setup_env():
         "npu_coords": {},
         "pe_coords": {},
         "cp_coords": {},
-        "dram_coords": {},
+        "iod_coords": {},
     }
     mesh = create_mesh(engine, 3, 1, mesh_info, buffer_capacity=1)
     mesh_info["router_map"] = mesh
@@ -25,11 +25,11 @@ def setup_env():
     mesh_info["npu_coords"]["NPU_0"] = (0, 0)
     mesh[(0, 0)].attach_module(npu)
     engine.register_module(npu)
-    dram = DRAM(engine, "DRAM", mesh_info, pipeline_latency=2, num_channels=1, buffer_capacity=1)
-    mesh_info["dram_coords"]["DRAM"] = (1, 0)
-    mesh[(1, 0)].attach_module(dram)
-    engine.register_module(dram)
-    cp = ControlProcessor(engine, "CP", mesh_info, [], dram, npus=[npu], buffer_capacity=1)
+    iod = IOD(engine, "IOD", mesh_info, pipeline_latency=2, channels_per_stack=16, buffer_capacity=1)
+    mesh_info["iod_coords"]["IOD"] = (1, 0)
+    mesh[(1, 0)].attach_module(iod)
+    engine.register_module(iod)
+    cp = ControlProcessor(engine, "CP", mesh_info, [], iod, npus=[npu], buffer_capacity=1)
     mesh_info["cp_coords"]["CP"] = (2, 0)
     mesh[(2, 0)].attach_module(cp)
     engine.register_module(cp)
@@ -48,8 +48,8 @@ class CPSerializationTest(unittest.TestCase):
             "cmd_opcode_cycles": 3,
         }
         instrs = [
-            {"event_type": "NPU_DMA_IN", "payload": dict(cfg, stream_id=0)},
-            {"event_type": "NPU_DMA_IN", "payload": dict(cfg, stream_id=0)},
+            {"event_type": "NPU_DMA_IN", "payload": dict(cfg, stream_id=0, eaddr=0, iaddr=0)},
+            {"event_type": "NPU_DMA_IN", "payload": dict(cfg, stream_id=0, eaddr=64, iaddr=64)},
         ]
         cp.load_program("p", instrs)
         cp.send_event(Event(src=None, dst=cp, cycle=1, program="p", event_type="RUN_PROGRAM"))


### PR DESCRIPTION
## Summary
- add new IOD memory model with stacks and channels
- route NPU DMA traffic to IOD using physical addresses
- support eaddr/iaddr fields for DMA operations
- update CP and NPU to work with IOD
- adjust unit tests for new module

## Testing
- `pip install torch torchvision torchaudio`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_686db145b8648330bcc95b2282abff88