### PR TITLE
Fix router buffering and test credits

### DIFF
--- a/sim_core/router.py
+++ b/sim_core/router.py
@@ -48,7 +48,7 @@ class Buffer(PipelineModule):
     def __init__(self, port, vc_idx, capacity):
         router = port.router
         name = f"{router.name}_P{port.port_idx}_VC{vc_idx}"
-        super().__init__(router.engine, name, router.mesh_info, 1, capacity, router.frequency)
+        super().__init__(router.engine, name, router.mesh_info, 1, capacity, router.frequency, stage_capacity=None)
         self.port = port
         self.vc_idx = vc_idx
         self.set_stage_funcs([lambda m, d: m._stage_rc(d)])
@@ -80,8 +80,6 @@ class Buffer(PipelineModule):
         event.payload["out_port"] = out_port
 
         q = self.port.va_stage_queues[self.vc_idx]
-        if len(q) >= self.port.buffer_capacity:
-            return event, self.RC, True
         q.append(event)
         self.port._schedule_va()
         return event, self.RC + 1, False
@@ -93,8 +91,15 @@ class Port(PipelineModule):
     VA = 0
 
     def __init__(self, router, port_idx, num_vcs, buffer_capacity):
-        super().__init__(router.engine, f"{router.name}_P{port_idx}",
-                         router.mesh_info, 1, buffer_capacity, router.frequency)
+        super().__init__(
+            router.engine,
+            f"{router.name}_P{port_idx}",
+            router.mesh_info,
+            1,
+            buffer_capacity,
+            router.frequency,
+            stage_capacity=None,
+        )
         self.router = router
         self.port_idx = port_idx
         self.num_vcs = num_vcs
@@ -132,8 +137,6 @@ class Port(PipelineModule):
         chosen = arbitrate_va(candidates)
         progress = False
         for (out_port, out_vc), vc_idx in chosen.items():
-            if len(self.router.sa_stage_queues[self.port_idx][vc_idx]) >= self.buffer_capacity:
-                continue
             pkt = self.va_stage_queues[vc_idx].pop(0)
             self.router.output_vc_allocation[out_port][out_vc] = pkt
             pkt.payload["out_vc"] = out_vc
@@ -161,7 +164,7 @@ class Router(PipelineModule):
     def __init__(self, engine, name, mesh_x, mesh_y, mesh_info,
                  bitwidth=256, pipeline_delay=4,
                  num_ports=5, num_vcs=2, buffer_capacity=4, frequency=1000):
-        super().__init__(engine, name, mesh_info, 4, buffer_capacity, frequency)
+        super().__init__(engine, name, mesh_info, 4, buffer_capacity, frequency, stage_capacity=None)
         self.x = mesh_x
         self.y = mesh_y
         self.bitwidth = bitwidth

--- a/tests/test_credit_return.py
+++ b/tests/test_credit_return.py
@@ -6,17 +6,29 @@ from sim_core.router import Router
 class CreditReturnTest(unittest.TestCase):
     def test_credits_restored(self):
         random.seed(1)
-        avg, engine, mesh = run_uniform_traffic_with_mesh(x=4, y=4, packets_per_node=20, max_tick=20000)
-        for coords, router in mesh.items():
-            for out_port in range(router.num_ports):
-                dest, _ = router.output_links[out_port]
-                if dest is None:
-                    continue
-                vc_count = router.port_num_vcs[out_port]
-                expected = dest.buffer_capacity
-                for vc in range(vc_count):
-                    credit = router.credit_counts[out_port][vc]
-                    self.assertEqual(credit, expected, f"{router.name} p{out_port} vc{vc}")
+        configs = [
+            (2, 2, 10),
+            (3, 2, 5),
+            (4, 4, 20),
+        ]
+        for x, y, ppn in configs:
+            avg, engine, mesh = run_uniform_traffic_with_mesh(
+                x=x, y=y, packets_per_node=ppn, max_tick=20000
+            )
+            for coords, router in mesh.items():
+                for out_port in range(router.num_ports):
+                    dest, _ = router.output_links[out_port]
+                    if dest is None:
+                        continue
+                    vc_count = router.port_num_vcs[out_port]
+                    expected = dest.buffer_capacity
+                    for vc in range(vc_count):
+                        credit = router.credit_counts[out_port][vc]
+                        self.assertEqual(
+                            credit,
+                            expected,
+                            f"{router.name} p{out_port} vc{vc} ({x}x{y}, {ppn})",
+                        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow PipelineModule to override per-stage capacity
- remove VC queue capacity checks in router stages
- disable pipeline stage limits in router buffers and ports
- expand credit return test to check multiple mesh sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68744b339a6c8330ad9d861dbab6ef25